### PR TITLE
Allow the trash directory to be set using trashdir

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -62,3 +62,5 @@ Patch that fixes using of invalid (or at least strange) item names in the
 stat structure by Kaspars Bankovskis.
 
 Chris Yuen provided a patch to fix compilation on Mac OS X.
+
+Chris Skalenda wrote a patch to allow setting the trash directory location.

--- a/data/vifm-help.txt
+++ b/data/vifm-help.txt
@@ -1616,11 +1616,11 @@ Command backgrounding
                  [+-]ext   - sort by extension
                  [+-]name  - sort by name (including extension)
                  [+-]iname - sort by name (including extension, ignores case)
-                 [+-]gid   - sort by group id
-                 [+-]gname - sort by group name
-                 [+-]mode  - sort by mode
-                 [+-]uid   - sort by owner id
-                 [+-]uname - sort by owner name
+                 [+-]gid   - sort by group id (*nix only)
+                 [+-]gname - sort by group name (*nix only)
+                 [+-]mode  - sort by mode (*nix only)
+                 [+-]uid   - sort by owner id (*nix only)
+                 [+-]uname - sort by owner name (*nix only)
                  [+-]size  - sort by size
                  [+-]atime - sort by time accessed
                  [+-]ctime - sort by time changed
@@ -1643,17 +1643,31 @@ Command backgrounding
               command-line).   Empty string means use same format like in pre‐
               vious versions.  Following macros are supported:
               %t - file name
-              %A - file permissions
+              %A - file attributes (permissions on *nix or properties on  Win‐
+              dows)
               %u - user name or uid (if it cannot be resolved)
               %g - group name or gid (if it cannot be resolved)
               %s - file size in human readable format
               %d - file modification date (uses 'timefmt' option)
               all 'rulerformat' macros
-              Percent sign can be followed by optional  minimum  field  width.
+              Percent  sign  can  be followed by optional minimum field width.
               Add '-' before minimum field width if you want field to be right
               aligned.  Example:
 
                set statusline="  %t%= %A %10u:%-7g %15s %20d "
+
+              On  Windows file properties include next flags (upper case means
+              flag is on):
+              A - archive
+              H - hidden
+              I - content isn't indexed
+              R - readonly
+              S - system
+              C - compressed
+              D - directory
+              E - encrypted
+              P - reparse point (e.g. symbolic link)
+              Z - sparse file
 
        sortorder
               type: enumeration
@@ -1681,6 +1695,12 @@ Command backgrounding
               default: true
               Use trash directory.
 
+       trashdir
+              type: string
+              default: "$HOME/.vifm/Trash"
+              Sets the trash directory. Will attempt to create  the  directory
+              if it does not exist.
+
        undolevels ul
               type: integer
               default: 100
@@ -1688,14 +1708,14 @@ Command backgrounding
 
        vicmd  type: string
               default: "vim"
-              The actual command used to start vi.  Ampersand sign at the  end
-              (regardless  whether  it's preceded by space or not) means back‐
+              The  actual command used to start vi.  Ampersand sign at the end
+              (regardless whether it's preceded by space or not)  means  back‐
               grounding of command.
 
        vixcmd type: string
               default: value of vicmd
-              The command used to start vi when in X.  Ampersand sign  at  the
-              end  (regardless  whether  it's  preceded by space or not) means
+              The  command  used to start vi when in X.  Ampersand sign at the
+              end (regardless whether it's preceded by  space  or  not)  means
               backgrounding of command.
 
        vifminfo
@@ -1728,7 +1748,7 @@ Command backgrounding
        wildmenu wmnu
               type: boolean
               default: false
-              Controls  whether  possible  matches of completion will be shown
+              Controls whether possible matches of completion  will  be  shown
               above the command line.
 
        wrap   type: boolean
@@ -1741,7 +1761,7 @@ Command backgrounding
               Searches wrap around end of the list.
 
 Mappings
-       Since it's not easy to enter special characters there are several  spe‐
+       Since  it's not easy to enter special characters there are several spe‐
        cial sequences that can be used in place of them.  They are:
 
        <cr>   Enter key
@@ -1751,12 +1771,12 @@ Mappings
        <tab> <s-tab>
               Tabulation and Shift+Tabulation keys
 
-       <esc>  <space>  <home> <end> <left> <right> <up> <down> <pageup> <page‐
+       <esc> <space> <home> <end> <left> <right> <up> <down>  <pageup>  <page�‐
        down>
               Keys with obvious names.
 
        <del> <delete>
-              Delete key.   <del>  and  <delete>  mean  different  codes,  but
+              Delete  key.   <del>  and  <delete>  mean  different  codes, but
               <delete> is more common.
 
        <c-a>,<c-b>,...,<c-z>,<c-[>,<c->,<c-]>,<c-^>,<c-_>
@@ -1784,13 +1804,13 @@ Mappings
               only for MS-Windows
               Functional keys with Shift key pressed.
 
-       vifm  removes  whitespace  characters  at the beginning and end of com‐
-       mands.  That's why you may want to use <space> at the  end  of  rhs  in
+       vifm removes whitespace characters at the beginning  and  end  of  com‐
+       mands.   That's  why  you  may want to use <space> at the end of rhs in
        mappings.  For example:
 
         cmap <f1> man<space>
 
-       will  put  "man " in line when you hit the <f1> key in the command line
+       will put "man " in line when you hit the <f1> key in the  command  line
        mode.
 
 Compatibility mode
@@ -1803,18 +1823,18 @@ Compatibility mode
 Menus and dialogs
        General
 
-       j, k - move.  <Escape>, Ctrl-C, ZZ, ZQ - quit.  <Return>,  l  -  select
+       j,  k  -  move.  <Escape>, Ctrl-C, ZZ, ZQ - quit.  <Return>, l - select
        and exit the menu.  Ctrl-L - redraw the menu.
 
        In all menus
 
-       Ctrl-B/Ctrl-F  Ctrl-D/Ctrl-U  Ctrl-E/Ctrl-Y / and ?, n/N [num]G/[num]gg
-       H/M/L zb/zt/zz zh - scroll menu items [count] characters to the  right.
-       zl  -  scroll  menu  items [count] characters to the left.  zH - scroll
-       menu items half of screen width characters to the right.  zL  -  scroll
+       Ctrl-B/Ctrl-F Ctrl-D/Ctrl-U Ctrl-E/Ctrl-Y / and ?,  n/N  [num]G/[num]gg
+       H/M/L  zb/zt/zz zh - scroll menu items [count] characters to the right.
+       zl - scroll menu items [count] characters to the  left.   zH  -  scroll
+       menu  items  half of screen width characters to the right.  zL - scroll
        menu items half of screen width characters to the left.
 
-       All  these  keys  have the same meaning as in normal mode (but not L in
+       All these keys have the same meaning as in normal mode (but  not  L  in
        filetype menu).
 
        : - enter command line mode for menus (currently only :exi[t], :q[uit],
@@ -1822,7 +1842,7 @@ Menus and dialogs
 
        Apropos menu
 
-       l  key  wont close the menu allowing user to pick another man page, use
+       l key wont close the menu allowing user to pick another man  page,  use
        :q to close the menu.
 
        Commands menu
@@ -1836,15 +1856,15 @@ Menus and dialogs
 
        Directory stack menu
 
-       Pressing  l  or  Enter  on  directory  name  will rotate stack to place
+       Pressing l or Enter on  directory  name  will  rotate  stack  to  place
        selected directory pair at the top of the stack.
 
        Filetype menu
 
-       Commands from vifmrc are displayed above empty line. When all  commands
+       Commands  from vifmrc are displayed above empty line. When all commands
        below empty line were found in .desktop files.
 
-       J  and K - to move menu items L - save all commands above empty line as
+       J and K - to move menu items L - save all commands above empty line  as
        program list
 
        Fileinfo dialog
@@ -1853,7 +1873,7 @@ Menus and dialogs
 
        Sort dialog
 
-       h - switch ascending/descending.  Space - switch  ascending/descending.
+       h  - switch ascending/descending.  Space - switch ascending/descending.
        q - close dialog
 
        Attributes (permissions or properties) dialog
@@ -1866,17 +1886,17 @@ Menus and dialogs
 
        - X - means that it has different value for files in selection.
 
-       - d  (*nix only) - (only for execute flags) means u-x+X, g-x+X or o-x+X
-         argument for the chmod program.  If you want to remove execute  right
-         from  all  files,  but  preserve  it for directories, set all execute
+       - d (*nix only) - (only for execute flags) means u-x+X, g-x+X or  o-x+X
+         argument  for the chmod program.  If you want to remove execute right
+         from all files, but preserve it  for  directories,  set  all  execute
          flags to 'd' and check ´Set Recursively' flag.
 
 Startup
-       On startup vifm determines several variables that are used  during  the
+       On  startup  vifm determines several variables that are used during the
        session.  They are determined in the order they appear below.
 
-       On  *nix  systems $HOME is normally present and used as is.  On Windows
-       systems vifm tries to find correct  home  directory  in  the  following
+       On *nix systems $HOME is normally present and used as is.   On  Windows
+       systems  vifm  tries  to  find  correct home directory in the following
        order:
         - $HOME variable;
         - $USERPROFILE variable;
@@ -1898,27 +1918,27 @@ Startup
 Configure
        See Startup section above for the explanations on $VIFM and $MYVIFMRC.
 
-       The  vifmrc  file  contains  commands  that  will  be  executed on vifm
-       startup.  See $MYVIFMRC variable description for search algorithm  used
-       to  find  vifmrc.  Use it to set settings, mappings, filetypes etc.  To
+       The vifmrc file  contains  commands  that  will  be  executed  on  vifm
+       startup.   See $MYVIFMRC variable description for search algorithm used
+       to find vifmrc.  Use it to set settings, mappings, filetypes  etc.   To
        use multi line commands precede each next line with a slash (whitespace
-       before  slash  is  ignored,  but all spaces at the end of the lines are
+       before slash is ignored, but all spaces at the end  of  the  lines  are
        saved).  For example: set
            \smartcase equals "setsmartcase".  When set<space here>
             smartcase equals "set  smartcase".
 
-       The $VIFM/vifminfo file contains session settings.  You may edit it  by
-       hand  to change the settings, but it's not recommended to do that, edit
-       vifmrc instead.  You  can  control  what  settings  will  be  saved  in
+       The  $VIFM/vifminfo file contains session settings.  You may edit it by
+       hand to change the settings, but it's not recommended to do that,  edit
+       vifmrc  instead.   You  can  control  what  settings  will  be saved in
        vifminfo by setting ´vifminfo' option.  Vifm always writes this file on
        exit unless 'vifminfo' option is empty.  Bookmarks, commands, directory
-       history,  filetypes,  fileviewers  and registers in the file are merged
+       history, filetypes, fileviewers and registers in the  file  are  merged
        with vifm configuration (which has bigger priority).
 
-       The $VIFM/scripts directory can contain shell scripts.   vifm  modifies
-       it's  PATH  environment  variable to let user run those scripts without
-       specifying full path.  All subdirectories of the $VIFM/scripts will  be
-       added  to  PATH too.  Script in a subdirectory overlaps script with the
+       The  $VIFM/scripts  directory can contain shell scripts.  vifm modifies
+       it's PATH environment variable to let user run  those  scripts  without
+       specifying  full path.  All subdirectories of the $VIFM/scripts will be
+       added to PATH too.  Script in a subdirectory overlaps script  with  the
        same name in all its parent directories.
 
        The $VIFM/colors directory contains color schemes.
@@ -1930,9 +1950,9 @@ Plugin
 
          :EditVifm   select a file or files to open in the current buffer.
          :SplitVifm  split buffer and select a file or files to open.
-         :VsplitVifm vertically split buffer and select a  file  or  files  to
+         :VsplitVifm  vertically  split  buffer  and select a file or files to
        open.
-         :DiffVifm    select  a  file  or files to compare to the current file
+         :DiffVifm   select a file or files to compare  to  the  current  file
        with
                      :vert diffsplit.
          :TabVifm    select a file or files to open in tabs.
@@ -1940,17 +1960,17 @@ Plugin
        Each command accepts up to two arguments: left pane directory and right
        pane directory.
 
-       The  plugin  have  only  two  settings.   It's  a string variable named
-       g:vifm_term to let user  specify  command  to  run  gui  terminal.   By
-       default  it's  equal  to  ´xterm -e'.  And anoter string variable named
-       g:vifm_exec, which equals "vifm"  by  default  and  specifies  path  to
-       vifm's  executable.   To  pass  arguments to vifm use g:vifm_exec_args,
+       The plugin have only  two  settings.   It's  a  string  variable  named
+       g:vifm_term  to  let  user  specify  command  to  run gui terminal.  By
+       default it's equal to ´xterm -e'.  And  anoter  string  variable  named
+       g:vifm_exec,  which  equals  "vifm"  by  default  and specifies path to
+       vifm's executable.  To pass arguments  to  vifm  use  g:vifm_exec_args,
        which is empty by default.
 
-       To use the plugin copy the vifm.vim file  to  either  the  system  wide
+       To  use  the  plugin  copy  the vifm.vim file to either the system wide
        vim/plugin directory or into ~/.vim/plugin.
 
-       If  you would prefer not to use the plugin and it is in the system wide
+       If you would prefer not to use the plugin and it is in the system  wide
        plugin directory add
 
        let loaded_vifm=1

--- a/data/vifm.1
+++ b/data/vifm.1
@@ -1865,6 +1865,13 @@ default: true
 .br
 Use trash directory.
 .TP
+.BI trashdir
+type: string
+.br
+default: "$HOME/.vifm/Trash"
+.br
+Sets the trash directory. Will attempt to create the directory if it does not exist.
+.TP
 .BI "undolevels ul"
 type: integer
 .br

--- a/data/vim/doc/vifm.txt
+++ b/data/vim/doc/vifm.txt
@@ -1605,6 +1605,13 @@ type: boolean
 default: true
 Use trash directory.
 
+                                               *vifm-'trashdir'*
+trashdir
+type: string
+default: "$HOME/.vifm/Trash
+Sets the trash directory. Will attempt to create the directory if it does not
+exist.
+
                                                *vifm-'timeoutlen'* *vifm-'tm'*
 timeoutlen tm
 type: integer

--- a/src/config.c
+++ b/src/config.c
@@ -32,6 +32,7 @@
 #endif
 
 #include <ctype.h> /* isalnum */
+#include <errno.h>
 #include <stdio.h> /* FILE */
 #include <stdlib.h>
 #include <string.h>
@@ -77,7 +78,6 @@ static void create_config_dir(void);
 static void create_help_file(void);
 static void create_rc_file(void);
 #endif
-static void create_trash_dir(void);
 
 void
 init_config(void)
@@ -186,7 +186,6 @@ set_config_paths(void)
 	store_config_paths();
 
 	create_config_dir();
-	create_trash_dir();
 }
 
 /* tries to find home directory */
@@ -478,7 +477,7 @@ create_rc_file(void)
 #endif
 
 /* ensures existence of trash directory */
-static void
+void
 create_trash_dir(void)
 {
 	LOG_FUNC_ENTER;
@@ -486,7 +485,10 @@ create_trash_dir(void)
 	if(access(cfg.trash_dir, F_OK) == 0)
 		return;
 
-	(void)make_dir(cfg.trash_dir, 0777);
+	if(make_dir(cfg.trash_dir, 0777) != 0)
+		show_error_msgf("Error Setting Trash Directory",
+				"Could not set trash directory to %s: %s",
+				cfg.trash_dir, strerror(errno));
 }
 
 static void

--- a/src/config.h
+++ b/src/config.h
@@ -112,6 +112,7 @@ int source_file(const char *file);
 int is_old_config(void);
 int are_old_color_schemes(void);
 const char * get_vicmd(int *bg);
+void create_trash_dir(void);
 
 #endif
 

--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -71,6 +71,7 @@ static void tabstop_handler(OPT_OP op, optval_t val);
 static void timefmt_handler(OPT_OP op, optval_t val);
 static void timeoutlen_handler(OPT_OP op, optval_t val);
 static void trash_handler(OPT_OP op, optval_t val);
+static void trashdir_handler(OPT_OP op, optval_t val);
 static void undolevels_handler(OPT_OP op, optval_t val);
 static void vicmd_handler(OPT_OP op, optval_t val);
 static void vixcmd_handler(OPT_OP op, optval_t val);
@@ -182,6 +183,7 @@ static struct
 	{ "timefmt",     "",     OPT_STR,     0,                          NULL,            &timefmt_handler,     },
 	{ "timeoutlen",  "tm",   OPT_INT,     0,                          NULL,            &timeoutlen_handler,  },
 	{ "trash",       "",     OPT_BOOL,    0,                          NULL,            &trash_handler,       },
+	{ "trashdir",    "",     OPT_STR,     0,                          NULL,            &trashdir_handler,    },
 	{ "undolevels",  "ul",   OPT_INT,     0,                          NULL,            &undolevels_handler,  },
 	{ "vicmd",       "",     OPT_STR,     0,                          NULL,            &vicmd_handler,       },
 	{ "vixcmd",      "",     OPT_STR,     0,                          NULL,            &vixcmd_handler,      },
@@ -243,6 +245,7 @@ load_options_defaults(void)
 	options[i++].val.str_val = cfg.time_format + 1;
 	options[i++].val.int_val = cfg.timeout_len;
 	options[i++].val.bool_val = cfg.use_trash;
+	options[i++].val.str_val = cfg.trash_dir;
 	options[i++].val.int_val = cfg.undo_levels;
 	options[i++].val.str_val = cfg.vi_command;
 	options[i++].val.str_val = cfg.vi_x_command;
@@ -827,6 +830,15 @@ static void
 trash_handler(OPT_OP op, optval_t val)
 {
 	cfg.use_trash = val.bool_val;
+}
+
+static void
+trashdir_handler(OPT_OP op, optval_t val)
+{
+	char * s = expand_tilde(strdup(val.str_val));
+	snprintf(cfg.trash_dir, sizeof(cfg.trash_dir), "%s", s);
+	create_trash_dir();
+	free(s);
 }
 
 static void

--- a/src/vifm.c
+++ b/src/vifm.c
@@ -606,6 +606,8 @@ main(int argc, char *argv[])
 		exec_config();
 	}
 
+	create_trash_dir();
+
 	check_path_for_file(&lwin, lwin_path, lwin_handle);
 	check_path_for_file(&rwin, rwin_path, rwin_handle);
 


### PR DESCRIPTION
This allows the user to move the trashdir out of $HOME/.vifm/Trash, if having it there is inconvenient for some reason (high-latency network mounted homedir, git-tracked dotfiles, etc.).

This is a re-submission from an earlier pull request, updated to reflect review comments:
https://github.com/xaizek/vifm/pull/1
