### PR TITLE
Use ^ instead of ! to skip .. directory, when matching entries with leading dot.

### DIFF
--- a/src/trash.c
+++ b/src/trash.c
@@ -244,7 +244,7 @@ empty_trash_dir(const char trash_dir[])
 	char *escaped;
 
 	escaped = escape_filename(trash_dir, 0);
-	snprintf(cmd, sizeof(cmd), "sh -c 'rm -rf %s/* %s/.[!.]*'", escaped, escaped);
+	snprintf(cmd, sizeof(cmd), "sh -c 'rm -rf %s/* %s/.[^.]*'", escaped, escaped);
 	free(escaped);
 
 	start_background_job(cmd, 0);


### PR DESCRIPTION
vifm fails to empty trash when trying to delete entries with leading dot. The ocurring error is:
`.]: Event not found.`

vifm tries to delete all entries with a leading dot in `.vifm/Trash` directory but also tries to skip `..` .
`.[!.]*` wildcard is being used for this. However, it looks like csh-like shells are not supporting this wildcard. Instead, they support `.[^.*]` wildcard. Tried sh, bash, tcsh, they support this as well.
