### PR TITLE
Filter colorschemes

### DIFF
--- a/src/color_scheme.c
+++ b/src/color_scheme.c
@@ -38,6 +38,8 @@
 #include "status.h"
 #include "ui.h"
 
+#define COLORSCHEME_EXTENSION ".vifm"
+
 char *HI_GROUPS[] = {
 	[WIN_COLOR]          = "Win",
 	[DIRECTORY_COLOR]    = "Directory",
@@ -381,7 +383,7 @@ list_color_schemes(int *len)
 {
 	char colors_dir[PATH_MAX];
 	snprintf(colors_dir, sizeof(colors_dir), "%s/colors", cfg.config_dir);
-	return list_regular_files(colors_dir, len);
+	return list_regular_files(colors_dir, COLORSCHEME_EXTENSION, len);
 }
 
 int

--- a/src/utils/fs.c
+++ b/src/utils/fs.c
@@ -390,7 +390,7 @@ get_file_size(const char *path)
 }
 
 char **
-list_regular_files(const char path[], int *len)
+list_regular_files(const char path[], char *extension, int *len)
 {
 	DIR *dir;
 	char **list = NULL;
@@ -402,6 +402,16 @@ list_regular_files(const char path[], int *len)
 		while((d = readdir(dir)) != NULL)
 		{
 			char full_path[PATH_MAX];
+
+			if (extension != NULL)
+			{
+				char *file_extension;
+				file_extension = strchr(d->d_name, '.');
+				if(file_extension == NULL)
+					continue;
+				if(strcmp(file_extension, extension) != 0)
+					continue;
+			}
 			snprintf(full_path, sizeof(full_path), "%s/%s", path, d->d_name);
 
 			if(is_regular_file(full_path))

--- a/src/utils/fs.h
+++ b/src/utils/fs.h
@@ -78,7 +78,7 @@ uint64_t get_file_size(const char *path);
 /* Lists all regular files inside the path directory.  Allocates an array of
  * strings, which should be freed by the caller.  Always sets *len.  Returns
  * NULL on error. */
-char ** list_regular_files(const char path[], int *len);
+char ** list_regular_files(const char path[], char *extension, int *len);
 
 /* Returns non-zero if file (or symbolic link target) path points to is a
  * regular file. */


### PR DESCRIPTION
Similar to vim, only display colorschemes with file extension '.vifm'.

Idea arose through through a [pull request in vifm-colors](https://github.com/vifm/vifm-colors/pull/2).