### PR TITLE
Check whether the cursor is already at the end of the line in cmd_end

### DIFF
--- a/src/modes/cmdline.c
+++ b/src/modes/cmdline.c
@@ -1916,6 +1916,9 @@ cmd_home(key_info_t key_info, keys_info_t *keys_info)
 static void
 cmd_end(key_info_t key_info, keys_info_t *keys_info)
 {
+	if(input_stat.index == input_stat.len)
+		return;
+
 	input_stat.index = input_stat.len;
 	input_stat.curs_pos = input_stat.prompt_wid +
 			wcswidth(input_stat.line, (size_t)-1);


### PR DESCRIPTION
Vifm segfaults when pressing `End` or `Ctrl+E` in the command prompt if the prompt was just opened.

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff4c5ce20 in wcswidth () from /usr/lib/libc.so.6

(gdb) backtrace
#0  0x00007ffff4c5ce20 in wcswidth () from /usr/lib/libc.so.6
#1  0x0000000000419d3a in cmd_end (key_info=..., keys_info=<optimized out>) at modes/cmdline.c:1921
#2  0x000000000040c93e in execute_mapping_handler (info=0x879538, keys_info=0x7fffffffb140, key_info=...) at engine/keys.c:1078
#3  dispatch_key (key_info=..., keys_info=keys_info@entry=0x7fffffffb140, curr=curr@entry=0x879520, keys=0x693944 <buf+4> L"") at engine/keys.c:501
#4  0x000000000040cd9b in execute_next_keys (curr=curr@entry=0x879520, keys=keys@entry=0x693944 <buf+4> L"", key_info=key_info@entry=0x7fffffffb0a0, keys_info=keys_info@entry=0x7fffffffb140, has_duplicate=<optimized out>, no_remap=no_remap@entry=0) at engine/keys.c:488
#5  0x000000000040d14f in dispatch_keys_at_root (keys=0x693944 <buf+4> L"", keys@entry=0x693940 <buf> L"Ũ", keys_info=keys_info@entry=0x7fffffffb140, root=<optimized out>, key_info=..., no_remap=no_remap@entry=0) at engine/keys.c:397
#6  0x000000000040d2fb in dispatch_keys (keys=keys@entry=0x693940 <buf> L"Ũ", keys_info=keys_info@entry=0x7fffffffb140, no_remap=no_remap@entry=0, prev_count=prev_count@entry=-1) at engine/keys.c:295
#7  0x000000000040d3cb in execute_keys_general (keys=keys@entry=0x693940 <buf> L"Ũ", timed_out=timed_out@entry=0, mapped=mapped@entry=0, no_remap=no_remap@entry=0) at engine/keys.c:249
#8  0x000000000040c8b5 in execute_keys_general_wrapper (keys=keys@entry=0x693940 <buf> L"Ũ", timed_out=timed_out@entry=0, no_remap=no_remap@entry=0, mapped=0) at engine/keys.c:229
#9  0x000000000040d669 in execute_keys (keys=keys@entry=0x693940 <buf> L"Ũ") at engine/keys.c:198
#10 0x000000000044402a in main_loop () at main_loop.c:229
#11 0x0000000000404c53 in main (argc=1, argv=0x7fffffffe348) at vifm.c:454

(gdb) p input_stat
$1 = {line = 0x0, initial_line = 0x0, index = 0, curs_pos = 1, len = 0, cmd_pos = -1, prompt = L":", '\000' <repeats 253 times>, prompt_wid = 1, complete_continue = 0, dot_pos = -1, dot_index = 0, dot_len = 0, history_search = HIST_NONE, hist_search_len = 0, 
  line_buf = 0x0, reverse_completion = 0, complete = 0x40af90 <complete_cmd>, search_mode = 0, old_top = 0, old_pos = 0, line_edited = 0, entered_by_mapping = 1}
```

(it crashes because `input_stat.line` is NULL)

Checking whether the cursor is already at the end of the line resolves this and probably prevents unnecessary cursor movements.
