### PR TITLE
Added example vifmrc-osx in /data

### DIFF
--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -1,5 +1,5 @@
 " vim: filetype=vifm :
-" Sample configuration file for vifm (last updated: 24 Oct, 2014)
+" Sample configuration file for vifm on OSX (last updated: 27 Mar, 2015)
 " You can edit this file by hand.
 " The " character at the beginning of a line comments out the line.
 " Blank lines are ignored.
@@ -8,12 +8,14 @@
 " ------------------------------------------------------------------------------
 
 " This is the actual command used to start vi.  The default is vim.
-" If you would like to use another vi clone such Elvis or Vile
-" you will need to change this setting.
+" If you would like to use another vi clone such Elvis or Vile, or if
+" you use Homebrew to manage your vim installation you will need to
+" change this setting.
 
 set vicmd=vim
 " set vicmd=elvis\ -G\ termcap
 " set vicmd=vile
+" set vicmd=/usr/local/bin/vim
 
 " Trash Directory
 " The default is to move files that are deleted with dd or :d to
@@ -67,7 +69,7 @@ colorscheme Default
 " Unless it exists with write/exec permissions set, vifm will attempt to
 " create it.
 
-set fusehome=/tmp/vifm_FUSE
+" set fusehome=/tmp/vifm_FUSE
 
 " Format for displaying time in file list. For example:
 " TIME_STAMP_FORMAT=%m/%d-%H:%M
@@ -75,7 +77,7 @@ set fusehome=/tmp/vifm_FUSE
 
 set timefmt=%m/%d\ %H:%M
 
-" Show list of matches on tab complition in command-line mode
+" Show list of matches on tab completion in command-line mode
 
 set wildmenu
 
@@ -142,6 +144,7 @@ command! reload :write | restart
 " :fileviewer pattern1,pattern2 consoleviewer
 " The other programs for the file type can be accessed with the :file command
 " The command macros %f, %F, %d, %F may be used in the commands.
+" Spaces in an app name will have to be escaped e.g. QuickTime\ Player.app
 " The %a macro is ignored.  To use a % you must put %%.
 
 " For automated FUSE mounts, you must register an extension with :file[x]type
@@ -163,75 +166,67 @@ command! reload :write | restart
 " program.
 
 " Pdf
-filextype *.pdf zathura %c %i &, apvlv %c, xpdf %c
+filetype *.pdf
+        \ {Open in Preview}
+        \ open -a Preview.app,
+        \ {Open in Skim}
+        \ open -a Skim.app,
 fileviewer *.pdf pdftotext -nopgbrk %c -
 
 " PostScript
-filextype *.ps,*.eps,*.ps.gz
-        \ {View in zathura}
-        \ zathura %f,
-        \ {View in gv}
-        \ gv %c %i &,
+filetype *.ps,*.eps open -a Preview.app
 
 " Djvu
-filextype *.djvu
-        \ {View in zathura}
-        \ zathura %f,
-        \ {View in apvlv}
-        \ apvlv %f,
+filetype *.djvu open -a MacDjView.app
 
 " Audio
 filetype *.wav,*.mp3,*.flac,*.ogg,*.m4a,*.wma,*.ape,*.ac3
-       \ {Play using ffplay}
-       \ ffplay -nodisp %c,
        \ {Play using MPlayer}
-       \ mplayer %f,
-       \ ffplay %c,
+       \ open -a MPlayerX.app,
+       \ {Open in iTunes}
+       \ open -a iTunes.app,
+       \ {Open in QuickTime Player}
+       \ open -a QuickTime\ Player.app,
 fileviewer *.mp3 mp3info
 fileviewer *.flac soxi
 
 " Video
-filextype *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
-        \ {View using ffplay}
-        \ ffplay -fs %c,
-        \ {View using Dragon}
-        \ dragon %f,
+filetype *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
+        \ {Open in VLC}
+        \ open -a VLC.app,
+        \ {Open in QuickTime Player}
+        \ open -a QuickTime\ Player.app,
         \ {View using mplayer}
-        \ mplayer %f,
+        \ open -a MPlayerX.app,
 fileviewer *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
          \ ffprobe -pretty %c 2>&1
 
 " Web
-filextype *.html,*.htm
-        \ {Open with dwb}
-        \ dwb %f %i &,
-        \ {Open with firefox}
-        \ firefox %f &,
-        \ {Open with uzbl}
-        \ uzbl-browser %f %i &,
-filetype *.html,*.htm links, lynx
+filetype *.html,*.htm
+        \ {Open in Safari}
+        \ open -a Safari.app,
+        \ {Open in Firefox}
+        \ open -a Firefox.app,
+        \ {Open in vim}
+        \ vim,
+fileviewer *.html,*.htm w3m -dump -T text/html
 
 " Object
 filetype *.o nm %f | less
 
 " Man page
-filetype *.[1-8] gtbl %c | groff -Tascii -man | less
-fileviewer *.[1-8] gtbl %c | groff -Tascii -man | col -b
+filetype *.[1-8] tbl %c | groff -Tascii -man | less
+fileviewer *.[1-8] tbl %c | groff -Tascii -man | col -b
 
 " Image
-filextype *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm
-        \ {View in sxiv}
-        \ sxiv,
-        \ {View in gpicview}
-        \ gpicview %c,
-        \ {View in shotwell}
-        \ shotwell,
+filetype *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm,
+        \ open -a Preview.app,
 fileviewer *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm convert -identify %f -verbose /dev/null
 
 " MD5
 filetype *.md5
        \ {Check MD5 hash sum}
-       \ md5sum -c %f,
+       \ md5 %f,
 
 " GPG signature
 filetype *.asc
@@ -239,70 +234,37 @@ filetype *.asc
        \ !!gpg --verify %c,
 
 " Torrent
-filetype *.torrent ktorrent %f &
+filetype *.torrent open -a Transmission.app
 fileviewer *.torrent dumptorrent -v %c
 
-" FuseZipMount
-filetype *.zip,*.jar,*.war,*.ear,*.oxt
-       \ {Mount with fuse-zip}
-       \ FUSE_MOUNT|fuse-zip %SOURCE_FILE %DESTINATION_DIR,
-       \ {View contents}
-       \ zip -sf %c | less,
-       \ {Extract here}
-       \ tar -xf %c,
-fileviewer *.zip,*.jar,*.war,*.ear,*.oxt zip -sf %c
+" Extract zip files
+filetype *.zip unzip %f
+fileviewer *.zip,*.jar,*.war,*.ear zip -sf %c
 
-" ArchiveMount
-filetype *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz,*.tar.xz,*.txz
-       \ {Mount with archivemount}
-       \ FUSE_MOUNT|archivemount %SOURCE_FILE %DESTINATION_DIR,
-fileviewer *.tgz,*.tar.gz tar -tzf %c
-fileviewer *.tar.bz2,*.tbz2 tar -tjf %c
-fileviewer *.tar.txz,*.txz xz --list %c
+" Extract tar archives
+filetype *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz tar -xf %f
+fileviewer *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz tar -tf %f
 
-" Rar2FsMount and rar archives
-filetype *.rar
-       \ {Mount with rar2fs}
-       \ FUSE_MOUNT|rar2fs %SOURCE_FILE %DESTINATION_DIR,
-fileviewer *.rar unrar v %c
+" Extract .bz2 archives
+filetype *.bz2 bzip2 -d %f
 
-" IsoMount
-filetype *.iso
-       \ {Mount with fuseiso}
-       \ FUSE_MOUNT|fuseiso %SOURCE_FILE %DESTINATION_DIR,
+" Extract .gz files
+filetype *.gz gunzip %f
 
-" SshMount
-filetype *.ssh
-       \ {Mount with sshfs}
-       \ FUSE_MOUNT2|sshfs %PARAM %DESTINATION_DIR,
+" Mount .dmg archives
+filetype *.dmg open
 
-" FtpMount
-filetype *.ftp
-       \ {Mount with curlftpfs}
-       \ FUSE_MOUNT2|curlftpfs -o ftp_port=-,,disable_eprt %PARAM %DESTINATION_DIR,
+" Mount disk .img
+filetype *.img open
 
-" Fuse7z and 7z archives
-filetype *.7z
-       \ {Mount with fuse-7z}
-       \ FUSE_MOUNT|fuse-7z %SOURCE_FILE %DESTINATION_DIR,
-fileviewer *.7z 7z l %c
+" Open .pkg binaries
+filetype *.pkg open
 
 " Office files
-filextype *.odt,*.doc,*.docx,*.xls,*.xlsx,*.odp,*.pptx libreoffice %f &
-fileviewer *.doc catdoc %c
+filetype *.odt,*.doc,*.docx,*.xls,*.xlsx,*.odp,*.pptx,*.ppt open -a LibreOffice.app
+fileviewer *.doc antiword -
 fileviewer *.docx, docx2txt.pl %f -
 
-" TuDu files
-filetype *.tudu tudu -f %c
-
-" Qt projects
-filextype *.pro qtcreator %f &
-
-" Directories
-filextype */
-        \ {View in thunar}
-        \ Thunar %f &,
-fileviewer .*/,*/ tree %f
 
 " Syntax highlighting in preview
 "
@@ -328,12 +290,8 @@ fileviewer .*/,*/ tree %f
 " settings).  By default all unknown files are opened with 'vi[x]cmd'
 " uncommenting one of lines below will result in ignoring 'vi[x]cmd' option
 " for unknown file types.
-" For *nix:
-" filetype * xdg-open
 " For OS X:
 " filetype * open
-" For Windows:
-" filetype * start, explorer
 
 " ------------------------------------------------------------------------------
 
@@ -370,32 +328,32 @@ nnoremap S :sort<cr>
 nnoremap w :view<cr>
 vnoremap w :view<cr>gv
 
-" Open file in existing instance of gvim
-nnoremap o :!gvim --remote-tab-silent %f<cr>
-" Open file in new instance of gvim
-nnoremap O :!gvim %f<cr>
+" Open file in new MacVim tab
+nmap o :!mvim --remote-tab-silent %f<cr>
+" Open file in new MacVim window
+nmap O :!mvim %f<cr>
 
 " Open file in the background using its default program
-nnoremap gb :file &<cr>l
+nnoremap gb :!open -g %f<cr>
 
 " Yank current directory path into the clipboard
-nnoremap yd :!echo %d | xclip %i<cr>
+nnoremap yd :!printf %d | pbcopy<cr>
 
 " Yank current file path into the clipboard
-nnoremap yf :!echo %c:p | xclip %i<cr>
+nnoremap yf :!printf %c:p | pbcopy<cr>
+
+" View preview in Quick Look
+nnoremap q :!qlmanage -p %f > /dev/null 2>&1<cr>
 
 " Mappings for faster renaming
 nnoremap I cw<c-a>
 nnoremap cc cw<c-u>
 nnoremap A cw<c-w>
 
-" Open console in current directory
-nnoremap ,t :!xterm &<cr>
-
 " Open vim to edit vifmrc and apply settings after returning to vifm
 nnoremap ,c :write | execute ':!vim $MYVIFMRC' | restart<cr>
-" Open gvim to edit vifmrc
-nnoremap ,C :!gvim --remote-tab-silent $MYVIFMRC &<cr>
+" Open MacVim to edit vifmrc
+nnoremap ,C :!mvim --remote-tab-silent $MYVIFMRC &<cr>
 
 " Toggle wrap setting on ,w key
 nnoremap ,w :set wrap!<cr>

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -178,12 +178,12 @@ filextype *.djvu open -a MacDjView.app
 
 " Audio
 filextype *.wav,*.mp3,*.flac,*.ogg,*.m4a,*.wma,*.ape,*.ac3
-       \ {Play using MPlayerX}
-       \ open -a MPlayerX.app,
-       \ {Open in iTunes}
-       \ open -a iTunes.app,
-       \ {Open in QuickTime Player}
-       \ open -a QuickTime\ Player.app,
+        \ {Play using MPlayerX}
+        \ open -a MPlayerX.app,
+        \ {Open in iTunes}
+        \ open -a iTunes.app,
+        \ {Open in QuickTime Player}
+        \ open -a QuickTime\ Player.app,
 fileviewer *.mp3 mp3info
 fileviewer *.flac soxi
 
@@ -196,7 +196,7 @@ filextype *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mo
         \ {Open in MPlayerX}
         \ open -a MPlayerX.app,
 fileviewer *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
-         \ ffprobe -pretty %c 2>&1
+        \ ffprobe -pretty %c 2>&1
 
 " Web
 filextype *.html,*.htm
@@ -224,13 +224,13 @@ fileviewer *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm convert -identify %f -verbose /d
 
 " MD5
 filetype *.md5
-       \ {Check MD5 hash sum}
-       \ md5 %f,
+        \ {Check MD5 hash sum}
+        \ md5 %f,
 
 " GPG signature
 filetype *.asc
-       \ {Check signature}
-       \ !!gpg --verify %c,
+        \ {Check signature}
+        \ !!gpg --verify %c,
 
 " Torrent
 filextype *.torrent open -a Transmission.app

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -8,7 +8,7 @@
 " ------------------------------------------------------------------------------
 
 " This is the actual command used to start vi.  The default is vim.
-" If you would like to use another vi clone such Elvis or Vile
+" If you would like to use another vi clone such as Elvis or Vile
 " you will need to change this setting.
 
 set vicmd=vim

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -66,8 +66,8 @@ colorscheme Default
 " The FUSE_HOME directory will be used as a root dir for all FUSE mounts.
 " Unless it exists with write/exec permissions set, vifm will attempt to
 " create it.
-" Have a look at FUSE for OSX https://osxfuse.github.io/
-set fusehome=/tmp/vifm_FUSE
+
+" set fusehome=/tmp/vifm_FUSE
 
 " Format for displaying time in file list. For example:
 " TIME_STAMP_FORMAT=%m/%d-%H:%M
@@ -236,23 +236,13 @@ filetype *.asc
 filextype *.torrent open -a Transmission.app
 fileviewer *.torrent dumptorrent -v %c
 
-" FuseZipMount
-filetype *.zip,*.jar,*.war,*.ear,*.oxt
-\ {Mount with fuse-zip}
-\ FUSE_MOUNT|fuse-zip %SOURCE_FILE %DESTINATION_DIR,
-\ {View contents}
-\ zip -sf %c | less,
-\ {Extract here}
-\ tar -xf %c,
-fileviewer *.zip,*.jar,*.war,*.ear,*.oxt zip -sf %c
+" Extract zip files
+filetype *.zip unzip %f
+fileviewer *.zip,*.jar,*.war,*.ear zip -sf %c
 
-" ArchiveMount
-filetype *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz,*.tar.xz,*.txz
-\ {Mount with archivemount}
-\ FUSE_MOUNT|archivemount %SOURCE_FILE %DESTINATION_DIR,
-fileviewer *.tgz,*.tar.gz tar -tzf %c
-fileviewer *.tar.bz2,*.tbz2 tar -tjf %c
-fileviewer *.tar.txz,*.txz xz --list %c
+" Extract tar archives
+filetype *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz tar -xf %f
+fileviewer *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz tar -tf %f
 
 " Extract .bz2 archives
 filetype *.bz2 bzip2 -d %f

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -8,14 +8,12 @@
 " ------------------------------------------------------------------------------
 
 " This is the actual command used to start vi.  The default is vim.
-" If you would like to use another vi clone such Elvis or Vile, or if
-" you use Homebrew to manage your vim installation you will need to
-" change this setting.
+" If you would like to use another vi clone such Elvis or Vile
+" you will need to change this setting.
 
 set vicmd=vim
 " set vicmd=elvis\ -G\ termcap
 " set vicmd=vile
-" set vicmd=/usr/local/bin/vim
 
 " Trash Directory
 " The default is to move files that are deleted with dd or :d to
@@ -98,7 +96,7 @@ set incsearch
 
 set scrolloff=4
 
-" Don't do to much requests to slow file systems
+" Don't do too many requests to slow file systems
 
 set slowfs=curlftpfs
 
@@ -133,7 +131,6 @@ command! zip zip -r %f.zip %f
 command! run !! ./%f
 command! make !!make %a
 command! mkcd :mkdir %a | cd %a
-command! vgrep vim "+grep %a"
 command! reload :write | restart
 
 " ------------------------------------------------------------------------------
@@ -181,7 +178,7 @@ filetype *.djvu open -a MacDjView.app
 
 " Audio
 filetype *.wav,*.mp3,*.flac,*.ogg,*.m4a,*.wma,*.ape,*.ac3
-       \ {Play using MPlayer}
+       \ {Play using MPlayerX}
        \ open -a MPlayerX.app,
        \ {Open in iTunes}
        \ open -a iTunes.app,
@@ -196,7 +193,7 @@ filetype *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov
         \ open -a VLC.app,
         \ {Open in QuickTime Player}
         \ open -a QuickTime\ Player.app,
-        \ {View using mplayer}
+        \ {Open in MPlayerX}
         \ open -a MPlayerX.app,
 fileviewer *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
          \ ffprobe -pretty %c 2>&1
@@ -207,6 +204,8 @@ filetype *.html,*.htm
         \ open -a Safari.app,
         \ {Open in Firefox}
         \ open -a Firefox.app,
+        \ {Open in Chrome}
+        \ open -a Google\ Chrome.app,
         \ {Open in vim}
         \ vim,
 fileviewer *.html,*.htm w3m -dump -T text/html
@@ -264,7 +263,6 @@ filetype *.pkg open
 filetype *.odt,*.doc,*.docx,*.xls,*.xlsx,*.odp,*.pptx,*.ppt open -a LibreOffice.app
 fileviewer *.doc antiword -
 fileviewer *.docx, docx2txt.pl %f -
-
 
 " Syntax highlighting in preview
 "

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -1,5 +1,6 @@
 " vim: filetype=vifm :
 " Sample configuration file for vifm on OSX (last updated: 27 Mar, 2015)
+" Copy to ~/.vifmrc and customise to your liking.
 " You can edit this file by hand.
 " The " character at the beginning of a line comments out the line.
 " Blank lines are ignored.

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -163,7 +163,7 @@ command! reload :write | restart
 " program.
 
 " Pdf
-filetype *.pdf
+filextype *.pdf
         \ {Open in Preview}
         \ open -a Preview.app,
         \ {Open in Skim}
@@ -171,13 +171,13 @@ filetype *.pdf
 fileviewer *.pdf pdftotext -nopgbrk %c -
 
 " PostScript
-filetype *.ps,*.eps open -a Preview.app
+filextype *.ps,*.eps open -a Preview.app
 
 " Djvu
-filetype *.djvu open -a MacDjView.app
+filextype *.djvu open -a MacDjView.app
 
 " Audio
-filetype *.wav,*.mp3,*.flac,*.ogg,*.m4a,*.wma,*.ape,*.ac3
+filextype *.wav,*.mp3,*.flac,*.ogg,*.m4a,*.wma,*.ape,*.ac3
        \ {Play using MPlayerX}
        \ open -a MPlayerX.app,
        \ {Open in iTunes}
@@ -188,7 +188,7 @@ fileviewer *.mp3 mp3info
 fileviewer *.flac soxi
 
 " Video
-filetype *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
+filextype *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
         \ {Open in VLC}
         \ open -a VLC.app,
         \ {Open in QuickTime Player}
@@ -199,7 +199,7 @@ fileviewer *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.m
          \ ffprobe -pretty %c 2>&1
 
 " Web
-filetype *.html,*.htm
+filextype *.html,*.htm
         \ {Open in Safari}
         \ open -a Safari.app,
         \ {Open in Firefox}
@@ -218,7 +218,7 @@ filetype *.[1-8] tbl %c | groff -Tascii -man | less
 fileviewer *.[1-8] tbl %c | groff -Tascii -man | col -b
 
 " Image
-filetype *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm,
+filextype *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm,
         \ open -a Preview.app,
 fileviewer *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm convert -identify %f -verbose /dev/null
 
@@ -233,7 +233,7 @@ filetype *.asc
        \ !!gpg --verify %c,
 
 " Torrent
-filetype *.torrent open -a Transmission.app
+filextype *.torrent open -a Transmission.app
 fileviewer *.torrent dumptorrent -v %c
 
 " Extract zip files
@@ -260,7 +260,7 @@ filetype *.img open
 filetype *.pkg open
 
 " Office files
-filetype *.odt,*.doc,*.docx,*.xls,*.xlsx,*.odp,*.pptx,*.ppt open -a LibreOffice.app
+filextype *.odt,*.doc,*.docx,*.xls,*.xlsx,*.odp,*.pptx,*.ppt open -a LibreOffice.app
 fileviewer *.doc antiword -
 fileviewer *.docx, docx2txt.pl %f -
 
@@ -327,9 +327,9 @@ nnoremap w :view<cr>
 vnoremap w :view<cr>gv
 
 " Open file in new MacVim tab
-nmap o :!mvim --remote-tab-silent %f<cr>
+nnoremap o :!mvim --remote-tab-silent %f<cr>
 " Open file in new MacVim window
-nmap O :!mvim %f<cr>
+nnoremap O :!mvim %f<cr>
 
 " Open file in the background using its default program
 nnoremap gb :!open -g %f<cr>

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -66,8 +66,8 @@ colorscheme Default
 " The FUSE_HOME directory will be used as a root dir for all FUSE mounts.
 " Unless it exists with write/exec permissions set, vifm will attempt to
 " create it.
-
-" set fusehome=/tmp/vifm_FUSE
+" Have a look at FUSE for OSX https://osxfuse.github.io/
+set fusehome=/tmp/vifm_FUSE
 
 " Format for displaying time in file list. For example:
 " TIME_STAMP_FORMAT=%m/%d-%H:%M
@@ -236,13 +236,23 @@ filetype *.asc
 filextype *.torrent open -a Transmission.app
 fileviewer *.torrent dumptorrent -v %c
 
-" Extract zip files
-filetype *.zip unzip %f
-fileviewer *.zip,*.jar,*.war,*.ear zip -sf %c
+" FuseZipMount
+filetype *.zip,*.jar,*.war,*.ear,*.oxt
+\ {Mount with fuse-zip}
+\ FUSE_MOUNT|fuse-zip %SOURCE_FILE %DESTINATION_DIR,
+\ {View contents}
+\ zip -sf %c | less,
+\ {Extract here}
+\ tar -xf %c,
+fileviewer *.zip,*.jar,*.war,*.ear,*.oxt zip -sf %c
 
-" Extract tar archives
-filetype *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz tar -xf %f
-fileviewer *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz tar -tf %f
+" ArchiveMount
+filetype *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz,*.tar.xz,*.txz
+\ {Mount with archivemount}
+\ FUSE_MOUNT|archivemount %SOURCE_FILE %DESTINATION_DIR,
+fileviewer *.tgz,*.tar.gz tar -tzf %c
+fileviewer *.tar.bz2,*.tbz2 tar -tjf %c
+fileviewer *.tar.txz,*.txz xz --list %c
 
 " Extract .bz2 archives
 filetype *.bz2 bzip2 -d %f

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -1,0 +1,425 @@
+" vim: filetype=vifm :
+" Sample configuration file for vifm (last updated: 24 Oct, 2014)
+" You can edit this file by hand.
+" The " character at the beginning of a line comments out the line.
+" Blank lines are ignored.
+" The basic format for each item is shown with an example.
+
+" ------------------------------------------------------------------------------
+
+" This is the actual command used to start vi.  The default is vim.
+" If you would like to use another vi clone such Elvis or Vile
+" you will need to change this setting.
+
+set vicmd=vim
+" set vicmd=elvis\ -G\ termcap
+" set vicmd=vile
+
+" Trash Directory
+" The default is to move files that are deleted with dd or :d to
+" the trash directory.  If you change this you will not be able to move
+" files by deleting them and then using p to put the file in the new location.
+" I recommend not changing this until you are familiar with vifm.
+" This probably shouldn't be an option.
+
+set trash
+
+" This is how many directories to store in the directory history.
+
+set history=100
+
+" Automatically resolve symbolic links on l or Enter.
+
+set nofollowlinks
+
+" With this option turned on you can run partially entered commands with
+" unambiguous beginning using :! (e.g. :!Te instead of :!Terminal or :!Te<tab>).
+
+set fastrun
+
+" Natural sort of (version) numbers within text.
+
+set sortnumbers
+
+" Maximum number of changes that can be undone.
+
+set undolevels=100
+
+" If you installed the vim.txt help file set vimhelp.
+" If would rather use a plain text help file set novimhelp.
+
+set novimhelp
+
+" If you would like to run an executable file when you
+" press return on the file name set this.
+
+set norunexec
+
+" Use KiB, MiB, ... instead of KB, MB, ...
+
+set noiec
+
+" Selected color scheme
+
+colorscheme Default
+
+" The FUSE_HOME directory will be used as a root dir for all FUSE mounts.
+" Unless it exists with write/exec permissions set, vifm will attempt to
+" create it.
+
+set fusehome=/tmp/vifm_FUSE
+
+" Format for displaying time in file list. For example:
+" TIME_STAMP_FORMAT=%m/%d-%H:%M
+" See man date or man strftime for details.
+
+set timefmt=%m/%d\ %H:%M
+
+" Show list of matches on tab complition in command-line mode
+
+set wildmenu
+
+" Ignore case in search patterns unless it contains at least one uppercase
+" letter
+
+set ignorecase
+set smartcase
+
+" Don't highlight search results automatically
+
+set nohlsearch
+
+" Use increment searching (search while typing)
+set incsearch
+
+" Try to leave some space from cursor to upper/lower border in lists
+
+set scrolloff=4
+
+" Don't do to much requests to slow file systems
+
+set slowfs=curlftpfs
+
+" Set custom status line look
+
+set statusline="  %t%= %A %10u:%-7g %15s %20d  "
+
+" ------------------------------------------------------------------------------
+
+" :mark mark /full/directory/path [filename]
+
+mark b ~/bin/
+mark h ~/
+
+" ------------------------------------------------------------------------------
+
+" :com[mand][!] command_name action
+" The following macros can be used in a command
+" %a is replaced with the user arguments.
+" %c the current file under the cursor.
+" %C the current file under the cursor in the other directory.
+" %f the current selected file, or files.
+" %F the current selected file, or files in the other directory.
+" %b same as %f %F.
+" %d the current directory name.
+" %D the other window directory name.
+" %m run the command in a menu window
+
+command! df df -h %m 2> /dev/null
+command! diff vim -d %f %F
+command! zip zip -r %f.zip %f
+command! run !! ./%f
+command! make !!make %a
+command! mkcd :mkdir %a | cd %a
+command! vgrep vim "+grep %a"
+command! reload :write | restart
+
+" ------------------------------------------------------------------------------
+
+" The file type is for the default programs to be used with
+" a file extension.
+" :filetype pattern1,pattern2 defaultprogram,program2
+" :fileviewer pattern1,pattern2 consoleviewer
+" The other programs for the file type can be accessed with the :file command
+" The command macros %f, %F, %d, %F may be used in the commands.
+" The %a macro is ignored.  To use a % you must put %%.
+
+" For automated FUSE mounts, you must register an extension with :file[x]type
+" in one of following formats:
+"
+" :filetype extensions FUSE_MOUNT|some_mount_command using %SOURCE_FILE and %DESTINATION_DIR variables
+" %SOURCE_FILE and %DESTINATION_DIR are filled in by vifm at runtime.
+" A sample line might look like this:
+" :filetype *.zip,*.jar,*.war,*.ear FUSE_MOUNT|fuse-zip %SOURCE_FILE %DESTINATION_DIR
+"
+" :filetype extensions FUSE_MOUNT2|some_mount_command using %PARAM and %DESTINATION_DIR variables
+" %PARAM and %DESTINATION_DIR are filled in by vifm at runtime.
+" A sample line might look like this:
+" :filetype *.ssh FUSE_MOUNT2|sshfs %PARAM %DESTINATION_DIR
+" %PARAM value is filled from the first line of file (whole line).
+" Example first line for SshMount filetype: root@127.0.0.1:/
+"
+" You can also add %CLEAR if you want to clear screen before running FUSE
+" program.
+
+" Pdf
+filextype *.pdf zathura %c %i &, apvlv %c, xpdf %c
+fileviewer *.pdf pdftotext -nopgbrk %c -
+
+" PostScript
+filextype *.ps,*.eps,*.ps.gz
+        \ {View in zathura}
+        \ zathura %f,
+        \ {View in gv}
+        \ gv %c %i &,
+
+" Djvu
+filextype *.djvu
+        \ {View in zathura}
+        \ zathura %f,
+        \ {View in apvlv}
+        \ apvlv %f,
+
+" Audio
+filetype *.wav,*.mp3,*.flac,*.ogg,*.m4a,*.wma,*.ape,*.ac3
+       \ {Play using ffplay}
+       \ ffplay -nodisp %c,
+       \ {Play using MPlayer}
+       \ mplayer %f,
+       \ ffplay %c,
+fileviewer *.mp3 mp3info
+fileviewer *.flac soxi
+
+" Video
+filextype *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
+        \ {View using ffplay}
+        \ ffplay -fs %c,
+        \ {View using Dragon}
+        \ dragon %f,
+        \ {View using mplayer}
+        \ mplayer %f,
+fileviewer *.avi,*.mp4,*.wmv,*.dat,*.3gp,*.ogv,*.mkv,*.mpg,*.vob,*.flv,*.m2v,*.mov,*.webm,*.ts,*.m4v
+         \ ffprobe -pretty %c 2>&1
+
+" Web
+filextype *.html,*.htm
+        \ {Open with dwb}
+        \ dwb %f %i &,
+        \ {Open with firefox}
+        \ firefox %f &,
+        \ {Open with uzbl}
+        \ uzbl-browser %f %i &,
+filetype *.html,*.htm links, lynx
+
+" Object
+filetype *.o nm %f | less
+
+" Man page
+filetype *.[1-8] gtbl %c | groff -Tascii -man | less
+fileviewer *.[1-8] gtbl %c | groff -Tascii -man | col -b
+
+" Image
+filextype *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm
+        \ {View in sxiv}
+        \ sxiv,
+        \ {View in gpicview}
+        \ gpicview %c,
+        \ {View in shotwell}
+        \ shotwell,
+fileviewer *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm convert -identify %f -verbose /dev/null
+
+" MD5
+filetype *.md5
+       \ {Check MD5 hash sum}
+       \ md5sum -c %f,
+
+" GPG signature
+filetype *.asc
+       \ {Check signature}
+       \ !!gpg --verify %c,
+
+" Torrent
+filetype *.torrent ktorrent %f &
+fileviewer *.torrent dumptorrent -v %c
+
+" FuseZipMount
+filetype *.zip,*.jar,*.war,*.ear,*.oxt
+       \ {Mount with fuse-zip}
+       \ FUSE_MOUNT|fuse-zip %SOURCE_FILE %DESTINATION_DIR,
+       \ {View contents}
+       \ zip -sf %c | less,
+       \ {Extract here}
+       \ tar -xf %c,
+fileviewer *.zip,*.jar,*.war,*.ear,*.oxt zip -sf %c
+
+" ArchiveMount
+filetype *.tar,*.tar.bz2,*.tbz2,*.tgz,*.tar.gz,*.tar.xz,*.txz
+       \ {Mount with archivemount}
+       \ FUSE_MOUNT|archivemount %SOURCE_FILE %DESTINATION_DIR,
+fileviewer *.tgz,*.tar.gz tar -tzf %c
+fileviewer *.tar.bz2,*.tbz2 tar -tjf %c
+fileviewer *.tar.txz,*.txz xz --list %c
+
+" Rar2FsMount and rar archives
+filetype *.rar
+       \ {Mount with rar2fs}
+       \ FUSE_MOUNT|rar2fs %SOURCE_FILE %DESTINATION_DIR,
+fileviewer *.rar unrar v %c
+
+" IsoMount
+filetype *.iso
+       \ {Mount with fuseiso}
+       \ FUSE_MOUNT|fuseiso %SOURCE_FILE %DESTINATION_DIR,
+
+" SshMount
+filetype *.ssh
+       \ {Mount with sshfs}
+       \ FUSE_MOUNT2|sshfs %PARAM %DESTINATION_DIR,
+
+" FtpMount
+filetype *.ftp
+       \ {Mount with curlftpfs}
+       \ FUSE_MOUNT2|curlftpfs -o ftp_port=-,,disable_eprt %PARAM %DESTINATION_DIR,
+
+" Fuse7z and 7z archives
+filetype *.7z
+       \ {Mount with fuse-7z}
+       \ FUSE_MOUNT|fuse-7z %SOURCE_FILE %DESTINATION_DIR,
+fileviewer *.7z 7z l %c
+
+" Office files
+filextype *.odt,*.doc,*.docx,*.xls,*.xlsx,*.odp,*.pptx libreoffice %f &
+fileviewer *.doc catdoc %c
+fileviewer *.docx, docx2txt.pl %f -
+
+" TuDu files
+filetype *.tudu tudu -f %c
+
+" Qt projects
+filextype *.pro qtcreator %f &
+
+" Directories
+filextype */
+        \ {View in thunar}
+        \ Thunar %f &,
+fileviewer .*/,*/ tree %f
+
+" Syntax highlighting in preview
+"
+" Explicitly set highlight type for some extensions
+"
+" 256-color terminal
+" fileviewer *.[ch],*.[ch]pp highlight -O xterm256 -s dante --syntax c %c
+" fileviewer Makefile,Makefile.* highlight -O xterm256 -s dante --syntax make %c
+"
+" 16-color terminal
+" fileviewer *.c,*.h highlight -O ansi -s dante %c
+"
+" Or leave it for automatic detection
+"
+" fileviewer * pygmentize -O style=monokai -f console256 -g
+
+" Displaying pictures in terminal
+"
+" fileviewer *.jpg,*.png shellpic %c
+
+" Open all other files with default system programs (you can also remove all
+" :file[x]type commands above to ensure they don't interfere with system-wide
+" settings).  By default all unknown files are opened with 'vi[x]cmd'
+" uncommenting one of lines below will result in ignoring 'vi[x]cmd' option
+" for unknown file types.
+" For *nix:
+" filetype * xdg-open
+" For OS X:
+" filetype * open
+" For Windows:
+" filetype * start, explorer
+
+" ------------------------------------------------------------------------------
+
+" What should be saved automatically between vifm runs
+" Like in previous versions of vifm
+" set vifminfo=options,filetypes,commands,bookmarks,dhistory,state,cs
+" Like in vi
+set vifminfo=dhistory,savedirs,chistory,state,tui,shistory,
+    \phistory,fhistory,dirstack,registers,bookmarks
+
+" ------------------------------------------------------------------------------
+
+" Examples of configuring both panels
+
+" Customize view columns a bit (enable ellipsis for truncated file names)
+"
+" windo set viewcolumns=-{name}..,6{}.
+
+" Filter-out build and temporary files
+"
+" windo filter! /^.*\.(lo|o|d|class|py[co])$|.*~$/
+
+" ------------------------------------------------------------------------------
+
+" Sample mappings
+
+" Start shell in current directory
+nnoremap s :shell<cr>
+
+" Display sorting dialog
+nnoremap S :sort<cr>
+
+" Toggle visibility of preview window
+nnoremap w :view<cr>
+vnoremap w :view<cr>gv
+
+" Open file in existing instance of gvim
+nnoremap o :!gvim --remote-tab-silent %f<cr>
+" Open file in new instance of gvim
+nnoremap O :!gvim %f<cr>
+
+" Open file in the background using its default program
+nnoremap gb :file &<cr>l
+
+" Yank current directory path into the clipboard
+nnoremap yd :!echo %d | xclip %i<cr>
+
+" Yank current file path into the clipboard
+nnoremap yf :!echo %c:p | xclip %i<cr>
+
+" Mappings for faster renaming
+nnoremap I cw<c-a>
+nnoremap cc cw<c-u>
+nnoremap A cw<c-w>
+
+" Open console in current directory
+nnoremap ,t :!xterm &<cr>
+
+" Open vim to edit vifmrc and apply settings after returning to vifm
+nnoremap ,c :write | execute ':!vim $MYVIFMRC' | restart<cr>
+" Open gvim to edit vifmrc
+nnoremap ,C :!gvim --remote-tab-silent $MYVIFMRC &<cr>
+
+" Toggle wrap setting on ,w key
+nnoremap ,w :set wrap!<cr>
+
+" Example of standard two-panel file managers mappings
+nnoremap <f3> :!less %f<cr>
+nnoremap <f4> :edit<cr>
+nnoremap <f5> :copy<cr>
+nnoremap <f6> :move<cr>
+nnoremap <f7> :mkdir<space>
+nnoremap <f8> :delete<cr>
+
+" ------------------------------------------------------------------------------
+
+" Various customization examples
+
+" Use ag (the silver searcher) instead of grep
+"
+" set grepprg=ag\ --line-numbers\ %i\ %a\ %s
+
+" Add additional place to look for executables
+"
+" let $PATH=$HOME.'/bin/fuse:'.$PATH
+
+" Block particular shortcut
+"
+" nnoremap <left> <nop>


### PR DESCRIPTION
This is a start on the example vifmrc-osx file.

I've ommitted or commented the Fuse options. I've removed the `vgrep` command, as I couldn't get it to work! I've included w3m as a fileviewer for web files; personal bias FTW. :smile:  I removed the tudu filetype, and I didn't include the qtcreator filetype: I had a bit of a look around and it looks (from [here](http://stanford.edu/~rawatson/qt/mac_install_gifs/)) like qrcreator is a bit of a major installation on OSX. I've tried to have sane defaults and a good spread of options to give a feel for what's possible. I *think* I matched your code style!

Any comments are welcome, I'm more than happy to tweak this until we feel it's right.

Closes #83.