### PR TITLE
Added * for slowfs

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -3312,7 +3312,9 @@ you.  This option can be used to stop vifm from making some requests to
 particular kinds of file systems that can slow down file browsing.
 Currently this means don't check if directory has changed, skip check if
 target of symbolic links exists, assume that link target located on slow fs
-to be a directory (allows entering directories and navigating to files via gf).
+to be a directory (allows entering directories and navigating to files via gf). 
+If you set the option to "*", it means all the systems are considered slow
+(usefull for cygwin, where all the checks will render vifm very slow). 
 
 Example for autofs root /mnt/autofs:
 .EX

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -2767,7 +2767,9 @@ particular kinds of file systems that can slow down file browsing.
 Currently this means don't check if directory has changed, skip check if
 target of symbolic links exists, assume that link target located on slow fs
 to be a directory (allows entering directories and navigating to files via
-|vifm-gf|).
+|vifm-gf|). If you set the option to "*", it means all the systems are
+considered slow (usefull for cygwin, where all the checks will render vifm
+very slow). 
 
 Example for autofs root /mnt/autofs: >
   set slowfs+=/mnt/autofs

--- a/src/utils/utils_nix.c
+++ b/src/utils/utils_nix.c
@@ -384,6 +384,15 @@ is_on_slow_fs(const char full_path[])
 		.curr_len = 0UL,
 	};
 
+	/* if slowfs = "*" then all file systems are considered slow
+	 * this function is very slow on cygwin
+	 */
+
+	if (strcmp(cfg.slow_fs_list, "*") == 0)
+	{
+		return 1;
+	}
+
 	/* Empty list optimization. */
 	if(cfg.slow_fs_list[0] == '\0')
 	{


### PR DESCRIPTION
I've added the possibility to set the `slowfs` option to `"*"`. This means that all directories are treated as slow. I did this because on `cygwin`, calling the `traverse_mount_points` and `start_with_list_item` function every second is very slow. 

So even if I am on a slow file system, and the system is included in the `slowfs` option, the overall experience is extremely poor. Setting the `slowfs` to `"*"` makes all the difference. `vifm` becomes usable also under `cygwin`.

There is also the possibility to check at a compile time with the preprocessor that `vifm` is running in `cygwin` and disable the `slowfs`, but maybe there are people who want to use it even slow under `cygwin`. So to me, this seems like the better option. 