### PR TITLE
Displaying match number for searches

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -476,7 +476,7 @@ static const cmd_add_t commands[] = {
 		.handler = screen_cmd,      .qmark = 1,      .expand = 0, .cust_sep = 0,         .min_args = 0, .max_args = 0,       .select = 0, },
 	{ .name = "set",              .abbr = "se",    .emark = 0,  .id = COM_SET,         .range = 0,    .bg = 0, .quote = 0, .regexp = 0,
 		.handler = set_cmd,         .qmark = 0,      .expand = 0, .cust_sep = 0,         .min_args = 0, .max_args = NOT_DEF, .select = 0, },
-	{ .name = "shell",            .abbr = "sh",    .emark = 0,  .id = -1,              .range = 0,    .bg = 0, .quote = 0, .regexp = 0,
+	{ .name = "shell",            .abbr = "sh",    .emark = 1,  .id = -1,              .range = 0,    .bg = 0, .quote = 0, .regexp = 0,
 		.handler = shell_cmd,       .qmark = 0,      .expand = 0, .cust_sep = 0,         .min_args = 0, .max_args = 0,       .select = 0, },
 	{ .name = "sort",             .abbr = "sor",   .emark = 0,  .id = -1,              .range = 0,    .bg = 0, .quote = 0, .regexp = 0,
 		.handler = sort_cmd,        .qmark = 0,      .expand = 0, .cust_sep = 0,         .min_args = 0, .max_args = 0,       .select = 0, },
@@ -3780,7 +3780,7 @@ shell_cmd(const cmd_info_t *cmd_info)
 
 	/* Run shell with clean PATH environment variable. */
 	load_clean_path_env();
-	shellout(sh, 0, 1);
+	shellout(sh, 0, cmd_info->emark ? 0 : 1);
 	load_real_path_env();
 
 	return 0;

--- a/src/modes/menu.c
+++ b/src/modes/menu.c
@@ -750,7 +750,8 @@ search(int backward)
 
 		if(menu->matching_entries > 0)
 		{
-			status_bar_messagef("(%d of %d) %c%s", get_match_index(menu), menu->matching_entries,
+			status_bar_messagef("(%d of %d) %c%s", get_match_index(menu),
+					menu->matching_entries,
 					backward ? '?' : '/', menu->regexp);
 		}
 	}
@@ -1095,7 +1096,7 @@ get_match_index(const menu_info *m)
 
 	n = 0;
 	i = 0;
-	while (i++ < m->current)
+	while (i++ < m->pos)
 	{
 		if (m->matches[i])
 		{
@@ -1103,7 +1104,7 @@ get_match_index(const menu_info *m)
 		}
 	}
 
-	return n;
+	return n + 1;
 }
 
 void

--- a/src/modes/menu.c
+++ b/src/modes/menu.c
@@ -750,7 +750,8 @@ search(int backward)
 
 		if(menu->matching_entries > 0)
 		{
-			status_bar_messagef("%c%s", backward ? '?' : '/', menu->regexp);
+			status_bar_messagef("(%d of %d) %c%s", get_match_index(menu), menu->matching_entries,
+					backward ? '?' : '/', menu->regexp);
 		}
 	}
 	else
@@ -1087,6 +1088,24 @@ execute_cmdline_command(const char cmd[])
 	init_cmds(0, &cmds_conf);
 }
 
+int
+get_match_index(const menu_info *m)
+{
+	int n, i;
+
+	n = 0;
+	i = 0;
+	while (i++ < m->current)
+	{
+		if (m->matches[i])
+		{
+			n++;
+		}
+	}
+
+	return n;
+}
+
 void
 menu_print_search_msg(const menu_info *m)
 {
@@ -1115,7 +1134,7 @@ menu_print_search_msg(const menu_info *m)
 
 	if(m->matching_entries > 0)
 	{
-		status_bar_messagef("%d %s", m->matching_entries,
+		status_bar_messagef("%d of %d %s", get_match_index(m), m->matching_entries,
 				(m->matching_entries == 1) ? "match" : "matches");
 	}
 	else

--- a/src/modes/menu.c
+++ b/src/modes/menu.c
@@ -1094,7 +1094,7 @@ get_match_index(const menu_info *m)
 {
 	int n, i;
 
-	n = 0;
+	n = (m->matches[0] ? 1 : 0);
 	i = 0;
 	while (i++ < m->pos)
 	{
@@ -1104,7 +1104,7 @@ get_match_index(const menu_info *m)
 		}
 	}
 
-	return n + 1;
+	return n;
 }
 
 void

--- a/src/modes/menu.h
+++ b/src/modes/menu.h
@@ -58,6 +58,9 @@ int get_last_visible_line(const menu_info *m);
 /* Prints results or error message about search operation to the user. */
 void menu_print_search_msg(const menu_info *m);
 
+/* Returns the index of the current match from the list of matches. */
+int get_match_index(const menu_info *m);
+
 #endif /* VIFM__MODES__MENU_H__ */
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */

--- a/src/modes/normal.c
+++ b/src/modes/normal.c
@@ -1653,8 +1653,7 @@ search(key_info_t key_info, int backward)
 
 	if(found)
 	{
-		status_bar_messagef("%c%s", backward ? '?' : '/',
-				cfg_get_last_search_pattern());
+		print_search_next_msg(curr_view, backward);
 	}
 	else
 	{

--- a/src/modes/visual.c
+++ b/src/modes/visual.c
@@ -943,8 +943,7 @@ search(key_info_t key_info, int backward, int interactive)
 		return;
 	}
 
-	status_bar_messagef("%c%s", backward ? '?' : '/',
-			cfg_get_last_search_pattern());
+	print_search_next_msg(view, backward);
 	curr_stats.save_msg = 1;
 }
 

--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -1589,6 +1589,7 @@ set_sort(FileView *view, char order[])
 	resort_view(view);
 	fview_cursor_redraw(view);
 	load_sort_option(view);
+	view->matches = 0;
 }
 
 /* Handles 'sortorder' option and corrects ordering for primary sorting key. */

--- a/src/search.c
+++ b/src/search.c
@@ -237,8 +237,10 @@ print_search_msg(const FileView *view, int backward)
 	}
 	else
 	{
-		status_bar_messagef("%d of %d matching file%s for: %s", view->dir_entry[view->list_pos].search_match,
-				view->matches, (view->matches == 1) ? "" : "s", cfg_get_last_search_pattern());
+		status_bar_messagef("%d of %d matching file%s for: %s",
+				view->dir_entry[view->list_pos].search_match,
+				view->matches,
+				(view->matches == 1) ? "" : "s", cfg_get_last_search_pattern());
 	}
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -146,7 +146,7 @@ find_pattern(FileView *view, const char pattern[], int backward, int move,
 				continue;
 			}
 
-			entry->search_match = 1;
+			entry->search_match = nmatches + 1;
 			entry->match_left = matches[0].rm_so;
 			entry->match_right = matches[0].rm_eo;
 			if(cfg.hl_search)
@@ -237,9 +237,16 @@ print_search_msg(const FileView *view, int backward)
 	}
 	else
 	{
-		status_bar_messagef("%d matching file%s for: %s", view->matches,
-				(view->matches == 1) ? "" : "s", cfg_get_last_search_pattern());
+		status_bar_messagef("%d of %d matching file%s for: %s", view->dir_entry[view->list_pos].search_match,
+				view->matches, (view->matches == 1) ? "" : "s", cfg_get_last_search_pattern());
 	}
+}
+
+void
+print_search_next_msg(const FileView *view, int backward)
+{
+	status_bar_messagef("(%d of %d) %c%s", view->dir_entry[view->list_pos].search_match,
+			view->matches, backward ? '?' : '/', cfg_get_last_search_pattern());
 }
 
 void

--- a/src/search.h
+++ b/src/search.h
@@ -50,6 +50,9 @@ void print_search_fail_msg(const FileView *view, int backward);
 /* Resets information about last search match. */
 void reset_search_results(FileView *view);
 
+/* Prints the search messages for the n or N commands. */
+void print_search_next_msg(const FileView *view, int backward);
+
 #endif /* VIFM__SEARCH_H__ */
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */


### PR DESCRIPTION
On a search result, display `(1 of 3) /pattern`. 

This is implemented for searches in normal mode and in visual mode and for searches in menus. 