### PR TITLE
dynamic page size for powerpc

### DIFF
--- a/src/utils/utils_nix.c
+++ b/src/utils/utils_nix.c
@@ -263,6 +263,9 @@ char **
 make_execv_array(char shell[], char cmd[])
 {
 #ifdef HAVE_MAX_ARG_STRLEN
+#ifndef PAGE_SIZE
+#define PAGE_SIZE sysconf(_SC_PAGESIZE)
+#endif
 	/* Don't use maximum length, leave some room or commands fail to run. */
 	const size_t safe_arg_len = MIN(MAX_ARG_STRLEN, MAX_ARG_STRLEN - 4096U);
 	const size_t npieces = DIV_ROUND_UP(strlen(cmd), safe_arg_len);


### PR DESCRIPTION
utils-nix.c needs dynamic PAGE_SIZE for powerpc
as not defined by default.

We received this patch into openSUSE from:
Michel Normand <normand@linux.vnet.ibm.com>