### PR TITLE
Dialog shortcuts

### DIFF
--- a/src/modes/dialogs/change_dialog.c
+++ b/src/modes/dialogs/change_dialog.c
@@ -43,6 +43,10 @@ static void cmd_gg(key_info_t key_info, keys_info_t *keys_info);
 static void goto_line(int line);
 static void cmd_j(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_k(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_n(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_o(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_g(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_p(key_info_t key_info, keys_info_t *keys_info);
 static void print_at_pos(void);
 static void clear_at_pos(void);
 
@@ -65,6 +69,10 @@ static keys_add_info_t builtin_cmds[] = {
 	{L"k", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_k}}},
 	{L"l", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_ctrl_m}}},
 	{L"q", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_ctrl_c}}},
+	{L"n", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_n}}},
+	{L"o", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_o}}},
+	{L"g", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_g}}},
+	{L"p", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_p}}},
 #ifdef ENABLE_EXTENDED_KEYS
 	{{KEY_UP}, {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_k}}},
 	{{KEY_DOWN}, {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_j}}},
@@ -105,7 +113,7 @@ enter_change_mode(FileView *active_view)
 	bottom = 4;
 #endif
 	curr = 2;
-	col = 6;
+	col = 5;
 	step = 2;
 
 	redraw_change_dialog();
@@ -123,15 +131,15 @@ redraw_change_dialog(void)
 	box(change_win, 0, 0);
 
 	mvwaddstr(change_win, 0, (x - 20)/2, " Change Current File ");
-	mvwaddstr(change_win, 2, 4, " [ ] Name");
+	mvwaddstr(change_win, 2, 3, " [ ] n Name");
 #ifndef _WIN32
-	mvwaddstr(change_win, 4, 4, " [ ] Owner");
-	mvwaddstr(change_win, 6, 4, " [ ] Group");
-	mvwaddstr(change_win, 8, 4, " [ ] Permissions");
+	mvwaddstr(change_win, 4, 3, " [ ] o Owner");
+	mvwaddstr(change_win, 6, 3, " [ ] g Group");
+	mvwaddstr(change_win, 8, 3, " [ ] p Permissions");
 #else
-	mvwaddstr(change_win, 4, 4, " [ ] Properties");
+	mvwaddstr(change_win, 4, 3, " [ ] p Properties");
 #endif
-	mvwaddch(change_win, 2, 6, '*');
+	mvwaddch(change_win, 2, 5, '*');
 
 	getmaxyx(stdscr, y, x);
 	mvwin(change_win, (y - getmaxy(change_win))/2, (x - getmaxx(change_win))/2);
@@ -238,6 +246,34 @@ cmd_k(key_info_t key_info, keys_info_t *keys_info)
 
 	print_at_pos();
 	wrefresh(change_win);
+}
+
+static void
+cmd_n(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(1);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_o(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(2);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_g(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(3);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_p(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(4);
+	cmd_ctrl_m(key_info, keys_info);
 }
 
 static void

--- a/src/modes/dialogs/sort_dialog.c
+++ b/src/modes/dialogs/sort_dialog.c
@@ -88,6 +88,25 @@ static void goto_line(int line);
 static void cmd_h(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_j(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_k(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_e(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_f(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_n(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_N(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_t(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_d(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_r(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_R(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_M(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_p(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_o(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_O(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_L(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_s(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_i(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_u(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_a(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_c(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_m(key_info_t key_info, keys_info_t *keys_info);
 static void print_at_pos(void);
 static void clear_at_pos(void);
 
@@ -110,6 +129,25 @@ static keys_add_info_t builtin_cmds[] = {
 	{L"k", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_k}}},
 	{L"l", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_ctrl_m}}},
 	{L"q", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_ctrl_c}}},
+	{L"e", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_e}}},
+	{L"f", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_f}}},
+	{L"n", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_n}}},
+	{L"N", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_N}}},
+	{L"t", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_t}}},
+	{L"d", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_d}}},
+	{L"r", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_r}}},
+	{L"R", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_R}}},
+	{L"M", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_M}}},
+	{L"p", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_p}}},
+	{L"o", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_o}}},
+	{L"O", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_O}}},
+	{L"L", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_L}}},
+	{L"s", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_s}}},
+	{L"i", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_i}}},
+	{L"u", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_u}}},
+	{L"a", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_a}}},
+	{L"c", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_c}}},
+	{L"m", {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_m}}},
 #ifdef ENABLE_EXTENDED_KEYS
 	{{KEY_UP}, {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_k}}},
 	{{KEY_DOWN}, {BUILTIN_KEYS, FOLLOWED_BY_NONE, {.handler = cmd_j}}},
@@ -148,7 +186,7 @@ enter_sort_mode(FileView *active_view)
 	top = 4;
 	bottom = top + SK_COUNT - 1;
 	curr = top + indexes[abs(view->sort[0])];
-	col = 6;
+	col = 4;
 
 	redraw_sort_dialog();
 }
@@ -169,34 +207,34 @@ redraw_sort_dialog(void)
 	mvwaddstr(sort_win, 0, (getmaxx(sort_win) - 6)/2, " Sort ");
 	mvwaddstr(sort_win, top - 2, 2, " Sort files by:");
 	cy = top;
-	mvwaddstr(sort_win, cy++, 4, " [   ] Extension");
-	mvwaddstr(sort_win, cy++, 4, " [   ] File Extension");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Name");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Name (ignore case)");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Type");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Dir");
+	mvwaddstr(sort_win, cy++, 2, " [   ] e Extension");
+	mvwaddstr(sort_win, cy++, 2, " [   ] f File Extension");
+	mvwaddstr(sort_win, cy++, 2, " [   ] n Name");
+	mvwaddstr(sort_win, cy++, 2, " [   ] N Name (ignore case)");
+	mvwaddstr(sort_win, cy++, 2, " [   ] t Type");
+	mvwaddstr(sort_win, cy++, 2, " [   ] d Dir");
 #ifndef _WIN32
-	mvwaddstr(sort_win, cy++, 4, " [   ] Group ID");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Group Name");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Mode");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Permissions");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Owner ID");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Owner Name");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Links Count");
+	mvwaddstr(sort_win, cy++, 2, " [   ] r Group ID");
+	mvwaddstr(sort_win, cy++, 2, " [   ] R Group Name");
+	mvwaddstr(sort_win, cy++, 2, " [   ] M Mode");
+	mvwaddstr(sort_win, cy++, 2, " [   ] p Permissions");
+	mvwaddstr(sort_win, cy++, 2, " [   ] o Owner ID");
+	mvwaddstr(sort_win, cy++, 2, " [   ] O Owner Name");
+	mvwaddstr(sort_win, cy++, 2, " [   ] L Links Count");
 #endif
-	mvwaddstr(sort_win, cy++, 4, " [   ] Size");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Item Count");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Groups");
-	mvwaddstr(sort_win, cy++, 4, " [   ] Time Accessed");
+	mvwaddstr(sort_win, cy++, 2, " [   ] s Size");
+	mvwaddstr(sort_win, cy++, 2, " [   ] i Item Count");
+	mvwaddstr(sort_win, cy++, 2, " [   ] u Groups");
+	mvwaddstr(sort_win, cy++, 2, " [   ] a Time Accessed");
 #ifndef _WIN32
-	mvwaddstr(sort_win, cy++, 4, " [   ] Time Changed");
+	mvwaddstr(sort_win, cy++, 2, " [   ] c Time Changed");
 #else
-	mvwaddstr(sort_win, cy++, 4, " [   ] Time Created");
+	mvwaddstr(sort_win, cy++, 2, " [   ] c Time Created");
 #endif
-	mvwaddstr(sort_win, cy++, 4, " [   ] Time Modified");
+	mvwaddstr(sort_win, cy++, 2, " [   ] m Time Modified");
 	assert(cy - top == SK_COUNT &&
 			"Sort dialog and sort options should not diverge");
-	mvwaddstr(sort_win, curr, 6, caps[descending]);
+	mvwaddstr(sort_win, curr, 4, caps[descending]);
 
 	wrefresh(sort_win);
 }
@@ -310,6 +348,139 @@ cmd_k(key_info_t key_info, keys_info_t *keys_info)
 
 	print_at_pos();
 	wrefresh(sort_win);
+}
+
+static void
+cmd_e(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 0);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_f(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 1);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_n(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 2);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_N(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 3);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_t(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 4);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_d(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 5);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_r(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 6);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_R(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 7);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_M(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 8);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_p(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 9);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_o(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 10);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_O(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 11);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_L(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 12);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_s(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 13 + CORRECTION);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_i(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 14 + CORRECTION);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_u(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 15 + CORRECTION);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_a(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 16 + CORRECTION);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_c(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 17 + CORRECTION);
+	cmd_ctrl_m(key_info, keys_info);
+}
+
+static void
+cmd_m(key_info_t key_info, keys_info_t *keys_info)
+{
+	goto_line(top + 18 + CORRECTION);
+	cmd_ctrl_m(key_info, keys_info);
 }
 
 static void


### PR DESCRIPTION
I added shortcuts for dialog options, because I often toggle between sort orders.

Thus with the default mapping of **S** to open the sort dialog:
* **Ss** sorts pane items by size
* **Se** sorts pane items by extension
* **SN** sorts pane items by name, ignoring case
* And so on...

![dialog-shortcuts](https://cloud.githubusercontent.com/assets/7405399/13459149/f35034bc-e071-11e5-917d-1ef4211ab552.png)

For completeness I also added [shortcuts to the change dialog](https://github.com/oo-/vifm/blob/76fe047f9880d618710cf6a375a43bdee6042c25/src/modes/dialogs/change_dialog.c#L134). Shortcuts did not seem relevant for msg or attr dialogs.

I tried to preserve the style of existing code and UI. I did not add any tests because I didn't understand vifm's testing scheme.