### PR TITLE
Travis OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os:
+  - linux
+  - osx
+
 language: c
 
 sudo: false

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -132,12 +132,12 @@ endif
 ifdef unix_env
     MF := $(B)../src/Makefile
     ifneq ($(wildcard $(MF)),)
-        LDFLAGS += $(shell sed -n    '/LIBS =/{s/^[^=]*=//p;q}' $(MF))
-        LDFLAGS += $(shell sed -n '/LDFLAGS =/{s/^[^=]*=//p;q}' $(MF))
+        LDFLAGS += $(shell grep -m1    'LIBS =' $(MF) | sed 's/^[^=]*=//')
+        LDFLAGS += $(shell grep -m1 'LDFLAGS =' $(MF) | sed 's/^[^=]*=//')
 
-        CFLAGS  += $(shell sed -n          '/CPPFLAGS =/{s/^[^=]*=//p;q}' $(MF))
-        CFLAGS  += $(shell sed -n      '/TESTS_CFLAGS =/{s/^[^=]*=//p;q}' $(MF))
-        CFLAGS  += $(shell sed -n '/SANITIZERS_CFLAGS =/{s/^[^=]*=//p;q}' $(MF))
+        CFLAGS  += $(shell grep -m1          'CPPFLAGS =' $(MF) | sed 's/^[^=]*=//')
+        CFLAGS  += $(shell grep -m1      'TESTS_CFLAGS =' $(MF) | sed 's/^[^=]*=//')
+        CFLAGS  += $(shell grep -m1 'SANITIZERS_CFLAGS =' $(MF) | sed 's/^[^=]*=//')
     endif
 
     CFLAGS += -I/usr/include/ncursesw


### PR DESCRIPTION
Hi,

I'm trying to enable OS X checks on Travis CI. I fixed non-compatible sed (not supporting {...} ).
It's still failing on unit tests, can you help me?

Thanks