### PR TITLE
use strncasecmp for non WIN32 platforms

### DIFF
--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -355,7 +355,7 @@ stroscmp(const char *s, const char *t)
 int
 strnoscmp(const char *s, const char *t, size_t n)
 {
-#ifndef _WIN32
+#ifdef _WIN32
 	return strncmp(s, t, n);
 #else
 	return strncasecmp(s, t, n);


### PR DESCRIPTION
this allows case insensitive autocomplete on unix platforms