### PR TITLE
Ability to format a name of a file moved to the trash directory

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -1,4 +1,4 @@
-.TH VIFM 1 "April 02, 2017" "vifm 0.8.2"
+.TH VIFM 1 "May 04, 2017" "vifm 0.8.2"
 .\" ---------------------------------------------------------------------------
 .SH NAME
 .\" ---------------------------------------------------------------------------
@@ -4177,6 +4177,38 @@ Default value tries to use trash directory per mount point and falls back to
 
 Will attempt to create the directory if it does not exist.  See
 "Trash directory" section below.
+.TP
+.BI 'trash_filefmt_zero'
+type: string
+.br
+default: "%name"
+.br
+The name of a file when it is moved to the trash directory and no other files in
+the trash directory have the same name. The '%name' token is replaced with the
+name of the actual file. The token can be combined with other characters, or
+with the '%count' token which in this case would always be zero.
+
+See also 'trash_filefmt_more'.
+.TP
+.BI 'trash_filefmt_more'
+type: string
+.br
+default: "%name (%count)"
+.br
+The name of a file when it is moved to the trash directory and other files exist
+in the trash directory with the same, or a similar name. The '%name' token is
+replaced with the name of the actual file, while the '%count' token is replaced
+with the number of files with the same or a similar name. The tokens can be
+combined with other characters.
+
+As an example, if there are two files with the names
+    example
+    example (1)
+in the trash directory, and the user deletes a third file called example (not in
+the trash directory), then the contents of the trash directory would become
+    example
+    example (1)
+    example (2)
 .TP
 .BI "'tuioptions' 'to'"
 type: charset

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -1,4 +1,4 @@
-*vifm-app.txt*    For Vifm version 0.8.2  Last change: 2017 Apr 02
+*vifm-app.txt*    For Vifm version 0.8.2  Last change: 2017 May 04
 
  Email for bugs and suggestions: <xaizek@openmailbox.org>
 
@@ -3469,6 +3469,39 @@ Default value tries to use trash directory per mount point and falls back to
 ~/.vifm/Trash on failure.
 
 Will attempt to create the directory if it does not exist.
+
+                                               *vifm-'trash_filefmt_zero'*
+trash_filefmt_zero
+type: string
+default: "%name"
+
+The name of a file when it is moved to the trash directory and no other files in
+the trash directory have the same name. The '%name' token is replaced with the
+name of the actual file. The token can be combined with other characters, or
+with the '%count' token which in this case would always be zero.
+
+See also 'trash_filefmt_more'.
+
+                                               *vifm-'trash_filefmt_more'*
+
+trash_filefmt_more
+type: string
+default: "%name (%count)"
+
+The name of a file when it is moved to the trash directory and other files exist
+in the trash directory with the same, or a similar name. The '%name' token is
+replaced with the name of the actual file, while the '%count' token is replaced
+with the number of files with the same or a similar name. The tokens can be
+combined with other characters.
+
+As an example, if there are two files with the names
+    example
+    example (1)
+in the trash directory, and the user deletes a third file called example (not in
+the trash directory), then the contents of the trash directory would become
+    example
+    example (1)
+    example (2)
 
                                                *vifm-'timeoutlen'* *vifm-'tm'*
 timeoutlen tm

--- a/data/vim/syntax/vifm.vim
+++ b/data/vim/syntax/vifm.vim
@@ -127,8 +127,9 @@ syntax keyword vifmOption contained aproposprg autochpos caseoptions cdpath cd
 		\ runexec scrollbind scb scrolloff so sort sortgroups sortorder sortnumbers
 		\ shell sh shortmess shm sizefmt slowfs smartcase scs statusline stl
 		\ suggestoptions syscalls tabstop timefmt timeoutlen title tm trash trashdir
-		\ ts tuioptions to undolevels ul vicmd viewcolumns vifminfo vimhelp vixcmd
-		\ wildmenu wmnu wildstyle wordchars wrap wrapscan ws
+		\ trash_filefmt_zero trash_filefmt_more ts tuioptions to undolevels ul vicmd
+		\ viewcolumns vifminfo vimhelp vixcmd wildmenu wmnu wildstyle wordchars wrap
+		\ wrapscan ws
 
 " Disabled boolean options
 syntax keyword vifmOption contained noautochpos nocf nochaselinks nodotfiles

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -206,6 +206,7 @@ vifm_SOURCES = \
 	utils/regexp.c utils/regexp.h \
 	utils/str.c utils/str.h \
 	utils/string_array.c utils/string_array.h \
+	utils/strnrep.c utils/strnrep.h \
 	utils/test_helpers.h \
 	utils/trie.c utils/trie.h \
 	utils/utf8.c utils/utf8.h \

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -226,11 +226,11 @@ am__v_P_1 = :
 AM_V_GEN = $(am__v_GEN_@AM_V@)
 am__v_GEN_ = $(am__v_GEN_@AM_DEFAULT_V@)
 am__v_GEN_0 = @echo "  GEN     " $@;
-am__v_GEN_1 = 
+am__v_GEN_1 =
 AM_V_at = $(am__v_at_@AM_V@)
 am__v_at_ = $(am__v_at_@AM_DEFAULT_V@)
 am__v_at_0 = @
-am__v_at_1 = 
+am__v_at_1 =
 DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
 depcomp = $(SHELL) $(top_srcdir)/depcomp
 am__depfiles_maybe = depfiles
@@ -240,13 +240,13 @@ COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 AM_V_CC = $(am__v_CC_@AM_V@)
 am__v_CC_ = $(am__v_CC_@AM_DEFAULT_V@)
 am__v_CC_0 = @echo "  CC      " $@;
-am__v_CC_1 = 
+am__v_CC_1 =
 CCLD = $(CC)
 LINK = $(CCLD) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS) -o $@
 AM_V_CCLD = $(am__v_CCLD_@AM_V@)
 am__v_CCLD_ = $(am__v_CCLD_@AM_DEFAULT_V@)
 am__v_CCLD_0 = @echo "  CCLD    " $@;
-am__v_CCLD_1 = 
+am__v_CCLD_1 =
 SOURCES = $(vifm_SOURCES) $(nodist_vifm_SOURCES)
 DIST_SOURCES = $(vifm_SOURCES)
 am__can_run_installinfo = \
@@ -761,6 +761,7 @@ vifm_SOURCES = \
 	utils/regexp.c utils/regexp.h \
 	utils/str.c utils/str.h \
 	utils/string_array.c utils/string_array.h \
+	utils/strnrep.c utils/strnrep.h \
 	utils/test_helpers.h \
 	utils/trie.c utils/trie.h \
 	utils/utf8.c utils/utf8.h \
@@ -1188,7 +1189,7 @@ utils/utils.$(OBJEXT): utils/$(am__dirstamp) \
 utils/utils_nix.$(OBJEXT): utils/$(am__dirstamp) \
 	utils/$(DEPDIR)/$(am__dirstamp)
 
-vifm$(EXEEXT): $(vifm_OBJECTS) $(vifm_DEPENDENCIES) $(EXTRA_vifm_DEPENDENCIES) 
+vifm$(EXEEXT): $(vifm_OBJECTS) $(vifm_DEPENDENCIES) $(EXTRA_vifm_DEPENDENCIES)
 	@rm -f vifm$(EXEEXT)
 	$(AM_V_CCLD)$(LINK) $(vifm_OBJECTS) $(vifm_LDADD) $(LIBS)
 install-dist_binSCRIPTS: $(dist_bin_SCRIPTS)

--- a/src/Makefile.win
+++ b/src/Makefile.win
@@ -72,8 +72,8 @@ ui := $(addprefix ui/, $(ui))
 
 utilities := cancellation.c dynarray.c env.c file_streams.c filemon.c filter.c \
              fs.c fsdata.c fsddata.c fswatch_win.c globs.c int_stack.c log.c \
-             matcher.c matchers.c path.c regexp.c str.c string_array.c trie.c \
-             utf8.c utils.c utils_win.c
+             matcher.c matchers.c path.c regexp.c str.c string_array.c strnrep.c \
+			 trie.c utf8.c utils.c utils_win.c
 utilities := $(addprefix utils/, $(utilities))
 
 vifm_SOURCES := $(cfg) $(compat) $(engine) $(int) $(io) $(menus) $(modes) \

--- a/src/cfg/config.c
+++ b/src/cfg/config.c
@@ -134,6 +134,8 @@ cfg_init(void)
 	cfg.vi_x_command = strdup("");
 	cfg.vi_x_cmd_bg = 0;
 	cfg.use_trash = 1;
+	cfg.trash_filefmt_zero = strdup("%name");
+	cfg.trash_filefmt_more = strdup("%name (%count)");
 	cfg.use_term_multiplexer = 0;
 	cfg.use_vim_help = 0;
 	cfg.wild_menu = 0;

--- a/src/cfg/config.h
+++ b/src/cfg/config.h
@@ -120,14 +120,16 @@ typedef struct config_t
 	char colors_dir[PATH_MAX + 8]; /* Where local color files are stored. */
 	char data_dir[PATH_MAX];       /* Where to store data files. */
 
+	int use_trash;
 	/* This one should be set using set_trash_dir() function. */
 	char trash_dir[PATH_MAX];
+	char *trash_filefmt_zero;
+	char *trash_filefmt_more;
 	char log_file[PATH_MAX];
 	char *vi_command;
 	int vi_cmd_bg;
 	char *vi_x_command;
 	int vi_x_cmd_bg;
-	int use_trash;
 
 	/* Whether support of terminal multiplexers is enabled. */
 	int use_term_multiplexer;

--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -195,6 +195,8 @@ static void timeoutlen_handler(OPT_OP op, optval_t val);
 static void title_handler(OPT_OP op, optval_t val);
 static void trash_handler(OPT_OP op, optval_t val);
 static void trashdir_handler(OPT_OP op, optval_t val);
+static void trash_filefmt_zero_handler(OPT_OP op, optval_t val);
+static void trash_filefmt_more_handler(OPT_OP op, optval_t val);
 static void tuioptions_handler(OPT_OP op, optval_t val);
 static void undolevels_handler(OPT_OP op, optval_t val);
 static void vicmd_handler(OPT_OP op, optval_t val);
@@ -675,6 +677,14 @@ options[] = {
 	{ "trashdir", "", "path to trash directory",
 	  OPT_STRLIST, 0, NULL, &trashdir_handler, NULL,
 	  { .init = &init_trashdir },
+	},
+	{ "trash_filefmt_zero", "", "file name when moved to the trash directory and no other files exist with the same name",
+	  OPT_STR, 0, NULL, &trash_filefmt_zero_handler, NULL,
+	  { .ref.str_val = &cfg.trash_filefmt_zero },
+	},
+	{ "trash_filefmt_more", "", "file name when moved to the trash directory and another file exists with the same name",
+	  OPT_STR, 0, NULL, &trash_filefmt_more_handler, NULL,
+	  { .ref.str_val = &cfg.trash_filefmt_more },
 	},
 	{ "tuioptions", "to", "TUI look tweaks",
 	  OPT_CHARSET, ARRAY_LEN(tuioptions_vals), tuioptions_vals,
@@ -2809,6 +2819,24 @@ trashdir_handler(OPT_OP op, optval_t val)
 		set_option("trashdir", val, OPT_GLOBAL);
 	}
 	free(expanded_path);
+}
+
+static void
+trash_filefmt_zero_handler(OPT_OP op, optval_t val)
+{
+	if (cfg.trash_filefmt_zero != NULL)
+		free(cfg.trash_filefmt_zero);
+	cfg.trash_filefmt_zero = malloc(strlen(val.str_val) + 1);
+	strcpy(cfg.trash_filefmt_zero, val.str_val);
+}
+
+static void
+trash_filefmt_more_handler(OPT_OP op, optval_t val)
+{
+	if (cfg.trash_filefmt_more != NULL)
+		free(cfg.trash_filefmt_more);
+	cfg.trash_filefmt_more = malloc(strlen(val.str_val) + 1);
+	strcpy(cfg.trash_filefmt_more, val.str_val);
 }
 
 /* Parses set of TUI flags and changes appearance configuration accordingly. */

--- a/src/utils/strnrep.c
+++ b/src/utils/strnrep.c
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2017, Alexandru Geana (alegen)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the names "Alexandru Geana" or "alegen" nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "strnrep.h"
+
+/**
+ * strmap_malloc() - allocate memory for a strmap_t object
+ * @mlen:       the maximum number of entries which can fit into the strmap
+ *
+ * The strmap_malloc() function allocates memory for one strmap_t object.
+ * Internally it uses malloc. The return value is a pointer to the newly
+ * allocated object. This pointer can be used further with other strmap_*
+ * functions.
+ *
+ * Return:      the return value is a pointer to a strmap_t* object
+ */
+strmap_t * strmap_malloc(size_t mlen) {
+    size_t i;
+    strmap_t *map;
+
+    map = (strmap_t*)malloc( sizeof(strmap_t) );
+    if (map == NULL)
+        goto fail_rollback;
+    memset(map, 0, sizeof(strmap_t));
+
+    map->len = mlen;
+    map->n_entries = 0;
+    map->entries = (char***)malloc( sizeof(char**) * mlen );
+    if (map->entries == NULL)
+        goto fail_rollback;
+
+    for (i = 0; i < mlen; i++) {
+        map->entries[i] = (char**)malloc( sizeof(char*) * 2 );
+        if (map->entries[i] == NULL)
+            goto fail_rollback;
+    }
+
+    return map;
+
+fail_rollback:
+    strmap_free(map);
+    return NULL;
+}
+
+/**
+ * strmap_free() - free memory allocated for a strmap_t object
+ * @map:        the strmap_t object to be freed
+ *
+ * The strmap_free() function is used to free memory allocated for a strmap_t
+ * object. The function uses free() internally.
+ */
+void strmap_free(strmap_t *map) {
+    size_t i;
+
+    if (map != NULL) {
+        if (map->entries != NULL) {
+            for (i = 0; i < map->len; i++) {
+                if (map->entries[i] != NULL)
+                    free( map->entries[i] );
+            }
+            free(map->entries);
+        }
+        free(map);
+    }
+}
+
+/**
+ * strmap_add() - add a new entry to a strmap_t object
+ * @map:        the strmap_t object on which to perform the action
+ * @key:        the key of the new map entry
+ * @val:        the value of the new map entry
+ *
+ * The strmap_add() function tries to insert one new entry into the map. The
+ * entry is specified as a combination of the key and val pair. If the action
+ * succeeds then the function retuns the value 0. If the action fails, the
+ * function returns a non-zero value.
+ *
+ * Return:      0 on success and non-zero on failure
+ */
+int strmap_add(strmap_t *map, char *key, char *val) {
+    if (map == NULL || key == NULL || val == NULL)
+        return 1;
+
+    if (map->len > map->n_entries) {
+        map->entries[ map->n_entries ][0] = strdup(key);
+        map->entries[ map->n_entries ][1] = strdup(val);
+
+        if (map->entries[ map->n_entries ][0] == NULL ||
+            map->entries[ map->n_entries ][1] == NULL)
+            return 1;
+
+        map->n_entries++;
+    } else
+        return 1;
+    return 0;
+}
+
+/**
+ * strmap_set() - set a new value for the entry with the specified key
+ * @map:        the strmap_t onject on which to perform the action
+ * @key:        the key of the entry to be changed
+ * @val:        the new value of the entry
+ *
+ * The strmap_set() function is used to modify the value of an entry with the
+ * specified key. If an entry with the specified key does not exist, the
+ * strmap_add() function is called internally. The mstrap_set() function returns
+ * 0 on success and a non-zero value on failure.
+ *
+ * Return:      0 on success and non-zero on failure
+ */
+int strmap_set(strmap_t *map, char *key, char *val) {
+    size_t i;
+
+    if (map == NULL || key == NULL || val == NULL)
+        return 1;
+
+    for (i = 0; i < map->n_entries; i++) {
+        if (map->entries[i][0] == NULL ||
+            map->entries[i][1] == NULL)
+            return 1;
+
+        if ( strcmp(key, map->entries[i][0]) == 0 ) {
+            free(map->entries[i][1]);
+            map->entries[i][1] = strdup(val);
+            if (map->entries[i][1] == NULL)
+                return 1;
+
+            // done, exit the function
+            return 0;
+        }
+    }
+
+    // if we reach this point, it means that the key
+    // was not found in the map so we try to add it
+    return strmap_add(map, key, val);
+}
+
+/**
+ * strnrep() - replace keys with values in string fmt
+ * @out:        the buffer in which the final result is placed
+ * @fmt:        the format string containing keys
+ * @olen:       length in bytes of the out buffer
+ * @map:        the strmap_t object containing keys and values
+ *
+ * The strnrep() function replaces occurences of keys with the value of the same
+ * entry. Pairs of keys and values are specified by the map argument. The map
+ * argument can be created and manipulated using the strmap_* functions. The
+ * olen argument specifies the maximum size of the final string.
+ *
+ * Return: the value of the out argument on success and NULL on failure
+ */
+char * strnrep(char *out, char *fmt, size_t olen, strmap_t *map) {
+    size_t keylen, vallen, d, i;
+    char *m, *aux;
+
+    if (fmt == NULL || out == NULL || map == NULL)
+        return NULL;
+
+    // allocate a scrap buffer
+    aux = (char*)malloc(olen);
+    if (aux == NULL)
+        return NULL;
+    memset(aux, 0, olen);
+
+    strncpy(out, fmt, olen);
+
+    // ensure out is a valid null terminated string
+    out[olen - 1] = '\0';
+
+    for (i = 0; i < map->n_entries; i++) {
+        if (map->entries[i] == NULL ||
+            map->entries[i][0] == NULL ||
+            map->entries[i][1] == NULL)
+            continue;
+
+        m = strstr(out, map->entries[i][0]);
+        if (m != NULL) {
+            keylen = strlen(map->entries[i][0]);
+            vallen = strlen(map->entries[i][1]);
+
+            d = m - out;
+
+            if (olen >= d) {
+                // copy the characters until the start of the format sequence
+                strncpy(aux, out, d);
+
+                // copy the mapping
+                strncpy(aux + d, map->entries[i][1], olen - d);
+
+                if (olen >= d + vallen) {
+                    // copy the remaining part of the initial string
+                    strncpy(aux + d + vallen, out + d + keylen, olen - d - vallen);
+                }
+
+                // ensure aux is a valid null terminated string
+                aux[olen - 1] = '\0';
+            } else {
+                continue;
+            }
+
+            strncpy(out, aux, olen);
+            // ensure out is a valid null terminated string
+            out[olen - 1] = '\0';
+        }
+    }
+
+    return out;
+}

--- a/src/utils/strnrep.h
+++ b/src/utils/strnrep.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017, Alexandru Geana (alegen)
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the names "Alexandru Geana" or "alegen" nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _STRNREP_H_
+#define _STRNREP_H_
+
+/**
+ * struct strmap_t - the basic map structure
+ * @len:        total number of entries which can fit into the map
+ * @n_entries:  current number of entries in the map
+ * @entries:    the actual entries, stored as entries[i][0] for the key
+ *              and entries[i][1] for the value of entry i; both key and
+ *              value are null terminated strings
+ *
+ * This structure defines the strmap_t type used by the strmap_* functions
+ * defined in file strnrep.c. Objects of this type can be allocated with
+ * strmap_malloc() and freed with strmap_free().
+ */
+typedef struct {
+    size_t len;
+    size_t n_entries;
+    char ***entries;
+} strmap_t;
+
+strmap_t * strmap_malloc(size_t mlen);
+void strmap_free(strmap_t *map);
+int strmap_add(strmap_t *map, char *key, char *val);
+int strmap_set(strmap_t *map, char *key, char *val);
+char * strnrep(char *out, char *fmt, size_t olen, strmap_t *map);
+
+#endif // _STRNREP_H_


### PR DESCRIPTION
Hello @xaizek,

For some time I have been meaning to add the ability of formatting the name of files moved to the trash directory. I needed this feature in order to better integrate my vifm workflow with some other scripts I made for myself along the years. Maybe some other people will find this useful. I would like to integrate these features upstream.

I am opening this pull request and am asking for your feedback. I tried to follow the same format that you are using, but am sure it is not 100% correct. Let me know what/how you would like to see improved in order to integrate the code into the official repo.

Also, I have ran some tests on linux and they seem to work well.

