### PR TITLE
Correctly change back current directory after view update

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,3 +113,6 @@ Dmitry Frank (a.k.a. dimonomid) fixed displaying size in statusline and
 implemented :histnext/:histprev commands.
 
 John Shea (a.k.a. coachshea) provided fix for the plugin related to neovim.
+
+Daniel Mueller fixed CWD of the process not matching current view after vifm
+picked up change in file system.

--- a/ChangeLog
+++ b/ChangeLog
@@ -169,6 +169,9 @@
 
 	Fixed the plugin in neovim.  Patch by John Shea (a.k.a. coachshea).
 
+	Fixed CWD of the process not matching current view after vifm picked up
+	change in file system.  Patch by Daniel Mueller.
+
 0.9-beta to 0.9
 
 	Escape $ and ` in %" macros on *nix systems.  Thanks to filterfalse.

--- a/THANKS
+++ b/THANKS
@@ -33,6 +33,7 @@ Cosmin Popescu (cosminadrianpopescu)
 Damian Ariel Perticone
 Daniel R. (r1chelt)
 Daniel Dettlaff (dmilith)
+Daniel Mueller (d-e-s-o)
 Daniel Polanco (dlpolanco)
 Denis Protivenskiy
 Dennis Hamester

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -1574,6 +1574,7 @@ populate_dir_list_internal(view_t *view, int reload)
 	if(vifm_chdir(view->curr_dir) != 0 && !is_unc_root(view->curr_dir))
 	{
 		LOG_SERROR_MSG(errno, "Can't chdir() into \"%s\"", view->curr_dir);
+		restore_cwd(saved_cwd);
 		return 1;
 	}
 

--- a/src/filelist.c
+++ b/src/filelist.c
@@ -1538,6 +1538,8 @@ load_dir_list_internal(view_t *view, int reload, int draw_only)
 static int
 populate_dir_list_internal(view_t *view, int reload)
 {
+	char *saved_cwd;
+
 	view->filtered = 0;
 
 	/* List reload usually implies that something related to file list has
@@ -1567,6 +1569,7 @@ populate_dir_list_internal(view_t *view, int reload)
 		update_all_windows();
 	}
 
+	saved_cwd = save_cwd();
 	/* this is needed for lstat() below */
 	if(vifm_chdir(view->curr_dir) != 0 && !is_unc_root(view->curr_dir))
 	{
@@ -1636,6 +1639,7 @@ populate_dir_list_internal(view_t *view, int reload)
 	{
 		if(rescue_from_empty_filelist(view))
 		{
+			restore_cwd(saved_cwd);
 			return 0;
 		}
 
@@ -1651,6 +1655,7 @@ populate_dir_list_internal(view_t *view, int reload)
 	 * changed while we were reading from it). */
 	update_dir_watcher(view);
 
+	restore_cwd(saved_cwd);
 	return 0;
 }
 

--- a/src/utils/fs.c
+++ b/src/utils/fs.c
@@ -159,6 +159,7 @@ path_exists_at(const char path[], const char filename[], int deref)
 	{
 		LOG_ERROR_MSG("Passed absolute path where relative one is expected: %s",
 				filename);
+		path = NULL;
 	}
 	return path_exists_internal(path, filename, deref);
 }


### PR DESCRIPTION
The file browser has the nice ability of changing the current working
directory to the currently displayed one. That changing happens
depending on which view is active, i.e., the left or the right side.
Unfortunately, if there are updates happening on the other side, for
example because a file increased its size, the current working directory
will be changed and not reverted as part of the view update process.
That is a problem when spawning off a new shell and expecting it to have
its working directory set to the currently active view's one.
This change fixes the problem by correctly restoring the current working
directory after each update operation.