### PR TITLE
Always place cursor on top for newly opened dirs

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,10 @@
 0.9.1-beta to current
 
+	Fixed opening a directory for which the saved cursor position is not at
+	the top: regardless of the cursor position we might have in the history,
+	when user hits Enter on a directory, the cursor should be placed on top.
+	Patch by Dmitry Frank (a.k.a. dimonomid).
+
 	Fixed :clone and :copy refusing to copy broken symbolic links, even though C
 	and p keys copy them.
 

--- a/src/running.c
+++ b/src/running.c
@@ -741,6 +741,11 @@ open_dir(view_t *view)
 	if(cd_is_possible(full_path))
 	{
 		navigate_to(view, full_path);
+
+		/* When opening a directory (effectively by hitting Enter on it), the
+		 * cursor should be placed on top regardless of the position we might have
+		 * in history */
+		view->list_pos = 0;
 	}
 }
 


### PR DESCRIPTION
Otherwise, consider this:

- Open directory `/foo/bar`
- Move cursor to some non-first item
- Type `:cd ..` (so that we'll end up in `/foo`)
- Hit Enter (so that we'll end up in `/foo/bar` again)

At this point, cursor should be on the top. Without the proposed change,
it isn't.

I guess it's a very minor thing for the majority, but I constantly
change directories via external means, so my directory history is
"polluted" by random cursor positions, and it's really annoying when I
open a dir and expect the cursor to be on top, while it isn't.