### PR TITLE
Remove the leading space from timefmt

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -4380,7 +4380,7 @@ Number of spaces that a Tab in the file counts for.
 .BI 'timefmt'
 type: string
 .br
-default: " %m/%d %H:%M"
+default: "%m/%d %H:%M"
 .br
 Format of time in file list.  See "man 1 date" or "man 3 strftime" for details.
 .TP

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -3639,7 +3639,7 @@ Number of spaces that a Tab in the file counts for.
                                                *vifm-'timefmt'*
 timefmt
 type: string
-default: " %m/%d %H:%M"
+default: "%m/%d %H:%M"
 
 Format of time in file list.  See man date or man strftime for details.
 

--- a/src/cfg/config.c
+++ b/src/cfg/config.c
@@ -109,7 +109,7 @@ cfg_init(void)
 	cfg.history_len = 15;
 
 	cfg.auto_execute = 0;
-	cfg.time_format = strdup(" %m/%d %H:%M");
+	cfg.time_format = strdup("%m/%d %H:%M");
 	cfg.wrap_quick_view = 1;
 	cfg.undo_levels = 100;
 	cfg.sort_numbers = 0;

--- a/src/cfg/info.c
+++ b/src/cfg/info.c
@@ -1023,7 +1023,7 @@ write_options(FILE *fp)
 	fprintf(fp, "=tabscope=%s\n",
 			escape_spaces(get_option_value("tabscope", OPT_GLOBAL)));
 	fprintf(fp, "=tabstop=%d\n", cfg.tab_stop);
-	fprintf(fp, "=timefmt=%s\n", escape_spaces(cfg.time_format + 1));
+	fprintf(fp, "=timefmt=%s\n", escape_spaces(cfg.time_format));
 	fprintf(fp, "=timeoutlen=%d\n", cfg.timeout_len);
 	fprintf(fp, "=%strash\n", cfg.use_trash ? "" : "no");
 	fprintf(fp, "=tuioptions=%s\n",

--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -1076,7 +1076,7 @@ to_endpoint(int i, char buffer[])
 static void
 init_timefmt(optval_t *val)
 {
-	val->str_val = cfg.time_format + 1;
+	val->str_val = cfg.time_format;
 }
 
 static void
@@ -3197,9 +3197,7 @@ static void
 timefmt_handler(OPT_OP op, optval_t val)
 {
 	free(cfg.time_format);
-	cfg.time_format = malloc(1 + strlen(val.str_val) + 1);
-	strcpy(cfg.time_format, " ");
-	strcat(cfg.time_format, val.str_val);
+	cfg.time_format = strdup(val.str_val);
 
 	redraw_lists();
 }

--- a/src/ui/fileview.c
+++ b/src/ui/fileview.c
@@ -1522,7 +1522,8 @@ format_time(int id, const void *data, size_t buf_len, char buf[])
 
 	if(tm_ptr != NULL)
 	{
-		strftime(buf, buf_len + 1, cfg.time_format, tm_ptr);
+		buf[0] = ' ';
+		strftime(buf + 1, buf_len, cfg.time_format, tm_ptr);
 	}
 	else
 	{


### PR DESCRIPTION
I still fail to understand why it was put there in the first place.