### PR TITLE
Set correct working directory on startup

### DIFF
--- a/src/event_loop.c
+++ b/src/event_loop.c
@@ -103,6 +103,10 @@ event_loop(const int *quit)
 	curr_input_buf = &input_buf[0];
 	curr_input_buf_pos = &input_buf_pos;
 
+	/* Make sure to set the working directory once in order to have the
+	 * desired state even before any events are processed. */
+	(void)vifm_chdir(flist_get_dir(curr_view));
+
 	while(!*quit)
 	{
 		wint_t c;


### PR DESCRIPTION
When vifm is started and it is configured to restore the previous
directory state (via set vifminfo=...,dhistory,savedirs,...), it will
set the program's current working directory according to that state.
However, the working directory ultimately set last is that of the right
file view, while the actually active file view is that on the left. That
causes confusion when forking off another program that will now have the
wrong working directory set.
To fix this problem this change reorders the auto-command triggering
code to first happen for the right view and only then for the left one.