### PR TITLE
Allow using more than 256 color pairs for preview.

### DIFF
--- a/src/ui/escape.c
+++ b/src/ui/escape.c
@@ -414,8 +414,7 @@ print_char_esc(WINDOW *win, const char str[], esc_state *state)
 	if(str[0] == '\033')
 	{
 		esc_state_update(state, str);
-		wattrset(win,
-				COLOR_PAIR(colmgr_get_pair(state->fg, state->bg)) | state->attrs);
+		wattr_set(win, state->attrs, colmgr_get_pair(state->fg, state->bg), NULL);
 	}
 	else
 	{


### PR DESCRIPTION
This is a minimal fix for the underlying issue causing https://github.com/hpjansson/chafa/issues/26 . It allows 65536 color pairs to be used in the preview. There are more calls to the obsolete wattrset() in vifm, but I don't think it will impact those, as the UI colors are allocated early on and should get low-numbered pairs.
