### PR TITLE
Simplify image preview

### DIFF
--- a/data/vifmrc
+++ b/data/vifmrc
@@ -238,7 +238,7 @@ filextype *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm
         \ {View in shotwell}
         \ shotwell,
 fileviewer *.bmp,*.jpg,*.jpeg,*.png,*.gif,*.xpm
-         \ convert -identify %f -verbose /dev/null
+         \ identify %f
 
 " OpenRaster
 filextype *.ora


### PR DESCRIPTION
Hi and thanks a lot for vifm!

The change simplifies the command to preview images and makes the output less redundant.

Instead of

    example.png PNG 1366x768 1366x768+0+0 8-bit sRGB 176847B 0.030u 0:00.026
    example.png=>/dev/null PNG 1366x768 1366x7 68+0+0 8-bit sRGB 176847B 0.200u 0:00.130

the output's now

    examlpe.png PNG 1366x768 1366x768+0+0 8-bit sRGB 176847B 0.000u 0:00.000

