### PR TITLE
Improve media menu

### DIFF
--- a/src/menus/media_menu.c
+++ b/src/menus/media_menu.c
@@ -206,7 +206,7 @@ reload_list(menu_data_t *m)
 	free(cmd);
 
 	int i;
-	const int menu_rows = (getmaxy(menu_win) + 1) - 3;
+	const int menu_rows = menu_win != NULL ? (getmaxy(menu_win) + 1) - 3 : 100;
 	int max_rows_with_blanks = info_count       /* Device lines. */
 		                       + (info_count - 1) /* Blank lines. */;
 	for(i = 0; i < info_count; ++i)

--- a/src/menus/media_menu.c
+++ b/src/menus/media_menu.c
@@ -27,41 +27,47 @@
 #include "../compat/fs_limits.h"
 #include "../compat/reallocarray.h"
 #include "../modes/dialogs/msg_dialog.h"
-#include "../ui/cancellation.h"
+#include "../ui/ui.h"
 #include "../ui/statusbar.h"
 #include "../utils/fs.h"
 #include "../utils/path.h"
 #include "../utils/str.h"
 #include "../utils/string_array.h"
 #include "../utils/utils.h"
-#include "../background.h"
+#include "../running.h"
 #include "menus.h"
 
 /* Example state of the menu:
  *
  *    Items                              Data            Action
  *
- *    /dev/sdc
- *     -- not mounted                    m/dev/sda3      mount /dev/sda3
+ *    /dev/sdc                                           mount /dev/sda3
+ *    `-- (not mounted)                  m/dev/sda3      mount /dev/sda3
  *
- *    /dev/sdd [label]
- *     -- /                              u/              unmount /
- *     -- /root/tmp                      u/root/tmp      unmount /root/tmp
+ *    /dev/sdd {text}
+ *    |-- /                              u/              unmount /
+ *    `-- /root/tmp                      u/root/tmp      unmount /root/tmp
+ *
+ *    /dev/sde                                           unmount /media
+ *    `-- /media                         u/media         unmount /media
  *
  * Additional keys:
  *  - r -- reload list
+ *  - [ -- previous device
+ *  - ] -- next device
  *  - m -- mount/unmount
  *
  * Behaviour on Enter:
- *  - for lines with mount-point: navigate inside it
- *  - for all other lines: just close the menu
+ *  - navigate inside mount-point or,
+ *  - mount device if there are no mount-points or,
+ *  - do nothing and keep menu open
  */
 
 /* Description of a single device. */
 typedef struct
 {
 	char *device;   /* Device name in the system. */
-	char *label;    /* Label of the device (can be NULL). */
+	char *text;     /* Arbitrary text next to device name (can be NULL). */
 	char **paths;   /* List of paths at which the device is mounted. */
 	int path_count; /* Number of elements in the paths array. */
 }
@@ -74,6 +80,10 @@ static int reload_list(menu_data_t *m);
 static void output_handler(const char line[], void *arg);
 static void free_info_array(void);
 static void position_cursor(menu_data_t *m);
+static const char *get_selected_data(menu_data_t *m);
+static void path_get_decors(const char path[], FileType type, const char **prefix,
+		const char **suffix);
+static int mediaprg_mount(const char *data, menu_data_t *m);
 
 /* List of media devices. */
 static media_info_t *infos;
@@ -103,13 +113,21 @@ show_media_menu(struct view_t *view)
 static int
 execute_media_cb(struct view_t *view, menu_data_t *m)
 {
-	const char *data = m->data[m->pos];
-	if(data != NULL && *data == 'u')
+	const char *data = get_selected_data(m);
+	if(data != NULL)
 	{
-		const char *path = m->data[m->pos] + 1;
-		menus_goto_dir(view, path);
+		if(*data == 'u')
+		{
+			const char *path = data + 1;
+			menus_goto_dir(view, path);
+			return 0;
+		}
+		else if(*data == 'm')
+		{
+			(void)mediaprg_mount(data, m);
+		}
 	}
-	return 0;
+	return 1;
 }
 
 /* Menu-specific shortcut handler.  Returns code that specifies both taken
@@ -122,51 +140,38 @@ media_khandler(struct view_t *view, menu_data_t *m, const wchar_t keys[])
 		reload_list(m);
 		return KHR_REFRESH_WINDOW;
 	}
-	else if(wcscmp(keys, L"m") == 0)
+	else if(wcscmp(keys, L"[") == 0)
 	{
-		const char *data = m->data[m->pos];
-		if(is_null_or_empty(data) || (*data != 'm' && *data != 'u') ||
-				cfg.media_prg[0] == '\0')
+		int i;
+		for(i = m->pos; i-- > 0; )
 		{
-			return KHR_REFRESH_WINDOW;
-		}
-
-		int mount = (*data == 'm');
-		const char *path = data + 1;
-
-		if(!mount)
-		{
-			/* Try to get out of mount point before trying to unmount it. */
-			char cwd[PATH_MAX + 1];
-			if(get_cwd(cwd, sizeof(cwd)) == cwd && is_in_subtree(cwd, path, 1))
+			if(m->data[i] == NULL && m->data[i + 1] != NULL)
 			{
-				char out_of_mount_path[PATH_MAX + 1];
-				snprintf(out_of_mount_path, sizeof(out_of_mount_path), "%s/..", path);
-				(void)vifm_chdir(out_of_mount_path);
+				menus_set_pos(m->state, i);
+				menus_partial_redraw(m->state);
+				break;
 			}
 		}
-
-		const char *action = (mount ? "mount" : "unmount");
-		const char *description = (mount ? "Mounting" : "Unmounting");
-
-		ui_sb_msgf("%s %s...", description, path);
-
-		char *escaped_path = shell_like_escape(path, 0);
-		char *cmd = format_str("%s %s %s", cfg.media_prg, action, escaped_path);
-		if(bg_and_wait_for_errors(cmd, &ui_cancellation_info) == 0)
+		return KHR_REFRESH_WINDOW;
+	}
+	else if(wcscmp(keys, L"]") == 0)
+	{
+		int i;
+		for(i = m->pos; ++i < m->len - 1; )
 		{
-			reload_list(m);
+			if(m->data[i] == NULL && m->data[i + 1] != NULL)
+			{
+				menus_set_pos(m->state, i);
+				menus_partial_redraw(m->state);
+				break;
+			}
 		}
-		else
-		{
-			show_error_msgf("Media operation error", "%s has failed", description);
-		}
-		free(escaped_path);
-		free(cmd);
-
-		ui_sb_clear();
-
-		menus_partial_redraw(m->state);
+		return KHR_REFRESH_WINDOW;
+	}
+	else if(wcscmp(keys, L"m") == 0)
+	{
+		const char *data = get_selected_data(m);
+		(void)mediaprg_mount(data, m);
 		return KHR_REFRESH_WINDOW;
 	}
 	return KHR_UNHANDLED;
@@ -201,25 +206,32 @@ reload_list(menu_data_t *m)
 	free(cmd);
 
 	int i;
+	const int menu_rows = (getmaxy(menu_win) + 1) - 3;
+	int max_rows_with_blanks = info_count       /* Device lines. */
+		                       + (info_count - 1) /* Blank lines. */;
 	for(i = 0; i < info_count; ++i)
 	{
+		max_rows_with_blanks += infos[i].path_count > 0 ?
+				infos[i].path_count : /* Mount-points. */
+				1;                    /* "Not mounted" line. */
+	}
+
+	for(i = 0; i < info_count; ++i)
+	{
+		const char *prefix, *suffix;
 		media_info_t *info = &infos[i];
 
 		put_into_string_array(&m->data, m->len, NULL);
-		if(is_null_or_empty(info->label))
-		{
-			m->len = add_to_string_array(&m->items, m->len, 1, info->device);
-		}
-		else
-		{
-			m->len = put_into_string_array(&m->items, m->len,
-					format_str("%s [%s]", info->device, info->label));
-		}
+
+		path_get_decors(info->device, FT_BLOCK_DEV, &prefix, &suffix);
+		m->len = put_into_string_array(&m->items, m->len,
+				format_str("%s%s%s %s", prefix, info->device, suffix,
+						info->text ? info->text : ""));
 
 		if(info->path_count == 0)
 		{
 			put_into_string_array(&m->data, m->len, format_str("m%s", info->device));
-			m->len = add_to_string_array(&m->items, m->len, 1, "  -- not mounted");
+			m->len = add_to_string_array(&m->items, m->len, 1, "`-- (not mounted)");
 		}
 		else
 		{
@@ -228,12 +240,19 @@ reload_list(menu_data_t *m)
 			{
 				put_into_string_array(&m->data, m->len,
 						format_str("u%s", info->paths[j]));
+
+				path_get_decors(info->paths[j], FT_DIR, &prefix, &suffix);
 				m->len = put_into_string_array(&m->items, m->len,
-						format_str("  -- %s", info->paths[j]));
+						format_str("%c-- %s%s%s",
+								j + 1 == info->path_count ? '`' : '|',
+								prefix,
+								(is_root_dir(info->paths[j]) && suffix[0] == '/') ? "" : info->paths[j],
+								suffix));
+
 			}
 		}
 
-		if(i != info_count - 1)
+		if(i != info_count - 1 && max_rows_with_blanks <= menu_rows)
 		{
 			put_into_string_array(&m->data, m->len, NULL);
 			m->len = add_to_string_array(&m->items, m->len, 1, "");
@@ -254,19 +273,27 @@ output_handler(const char line[], void *arg)
 		infos = reallocarray(infos, ++info_count, sizeof(*infos));
 		media_info_t *info = &infos[info_count - 1];
 		info->device = strdup(line);
-		info->label = NULL;
+		info->text = NULL;
 		info->paths = NULL;
 		info->path_count = 0;
 	}
-	else if(skip_prefix(&line, "label=") && info_count != 0)
+	else if(info_count > 0)
 	{
-		replace_string(&infos[info_count - 1].label, line);
-	}
-	else if(skip_prefix(&line, "mount-point=") && info_count != 0)
-	{
-		media_info_t *info = &infos[info_count - 1];
-		info->path_count = add_to_string_array(&info->paths, info->path_count, 1,
-				line);
+		if(skip_prefix(&line, "info="))
+		{
+			replace_string(&infos[info_count - 1].text, line);
+		}
+		else if(skip_prefix(&line, "label="))
+		{
+			replace_string(&infos[info_count - 1].text,
+					format_str("[%s]", line));
+		}
+		else if(skip_prefix(&line, "mount-point="))
+		{
+			media_info_t *info = &infos[info_count - 1];
+			info->path_count = add_to_string_array(&info->paths, info->path_count, 1,
+					line);
+		}
 	}
 }
 
@@ -279,7 +306,7 @@ free_info_array(void)
 	{
 		media_info_t *info = &infos[i];
 		free(info->device);
-		free(info->label);
+		free(info->text);
 		free_string_array(info->paths, info->path_count);
 	}
 	free(infos);
@@ -302,6 +329,105 @@ position_cursor(menu_data_t *m)
 			break;
 		}
 	}
+}
+
+/* Retrieves decorations for path. See: ui_get_decors(). */
+static void
+path_get_decors(const char path[], FileType type, const char **prefix,
+		const char **suffix)
+{
+	dir_entry_t entry;
+
+	entry.name = get_last_path_component(path);
+	/* Avoid memory allocation. */
+	if(entry.name != path)
+	{
+		entry.name[-1] = '\0';
+		entry.origin = entry.name;
+	}
+	else
+	{
+		entry.origin = type == FT_BLOCK_DEV ? "/dev" : "/";
+	}
+	entry.type = type;
+	entry.name_dec_num = -1;
+
+	ui_get_decors(&entry, prefix, suffix);
+
+	/* Restore original path. */
+	if(entry.name != path)
+	{
+		entry.name[-1] = '/';
+	}
+}
+
+/* Retrieves appropriate data for selected item in a human-friendly way. */
+static const char *
+get_selected_data(menu_data_t *m)
+{
+	const char *data = m->data[m->pos];
+	if(data == NULL)
+	{
+		const char *next_data     = m->pos + 1 < m->len ? m->data[m->pos + 1] : NULL;
+		const char *nextnext_data = m->pos + 2 < m->len ? m->data[m->pos + 2] : NULL;
+		if(next_data != NULL && nextnext_data == NULL)
+		{
+			data = next_data;
+		}
+	}
+	return data;
+}
+
+/* Executes "mount" or "unmount" command on data.  Returns non-zero if program
+ * executed successfully and zero otherwise. */
+static int
+mediaprg_mount(const char *data, menu_data_t *m)
+{
+	if(data == NULL || (*data != 'm' && *data != 'u') ||
+			cfg.media_prg[0] == '\0')
+	{
+		return 1;
+	}
+
+	int error = 0;
+	int mount = (*data == 'm');
+	const char *path = data + 1;
+
+	if(!mount)
+	{
+		/* Try to get out of mount point before trying to unmount it. */
+		char cwd[PATH_MAX + 1];
+		if(get_cwd(cwd, sizeof(cwd)) == cwd && is_in_subtree(cwd, path, 1))
+		{
+			char out_of_mount_path[PATH_MAX + 1];
+			snprintf(out_of_mount_path, sizeof(out_of_mount_path), "%s/..", path);
+			(void)vifm_chdir(out_of_mount_path);
+		}
+	}
+
+	const char *action = (mount ? "mount" : "unmount");
+	const char *description = (mount ? "Mounting" : "Unmounting");
+
+	ui_sb_msgf("%s %s...", description, path);
+
+	char *escaped_path = shell_like_escape(path, 0);
+	char *cmd = format_str("%s %s %s", cfg.media_prg, action, escaped_path);
+	if(shellout(cmd, PAUSE_NEVER, 0, SHELL_BY_APP) == 0)
+	{
+		reload_list(m);
+	}
+	else
+	{
+		error = 1;
+		show_error_msgf("Media operation error", "%s has failed", description);
+	}
+	free(escaped_path);
+	free(cmd);
+
+	ui_sb_clear();
+
+	menus_partial_redraw(m->state);
+	return error;
 }
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */

--- a/src/menus/media_menu.c
+++ b/src/menus/media_menu.c
@@ -285,7 +285,7 @@ output_handler(const char line[], void *arg)
 		}
 		else if(skip_prefix(&line, "label="))
 		{
-			replace_string(&infos[info_count - 1].text,
+			put_string(&infos[info_count - 1].text,
 					format_str("[%s]", line));
 		}
 		else if(skip_prefix(&line, "mount-point="))

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -1278,6 +1278,12 @@ ui_setup_for_menu_like(void)
 static void
 update_term_size(void)
 {
+	if(curr_stats.load_stage < 1)
+	{
+		/* No terminal in tests. */
+		return;
+	}
+
 #ifndef _WIN32
 	struct winsize ws = { .ws_col = -1, .ws_row = -1 };
 

--- a/tests/misc/integration.c
+++ b/tests/misc/integration.c
@@ -23,6 +23,7 @@
 SETUP()
 {
 	update_string(&cfg.shell, "");
+	update_string(&cfg.slow_fs_list, "");
 	assert_success(stats_init(&cfg));
 }
 

--- a/tests/misc/menus_media.c
+++ b/tests/misc/menus_media.c
@@ -28,6 +28,8 @@
 static char sandbox[PATH_MAX + 1];
 static char *saved_cwd;
 
+#define SHEBANG_ECHO "#!/usr/bin/tail -n+2"
+
 SETUP_ONCE()
 {
 	char cwd[PATH_MAX + 1];
@@ -95,10 +97,8 @@ TEST(script_failure_is_handled)
 TEST(menu_is_loaded)
 {
 	FILE *fp = fopen("script", "w");
-	fputs("#!/bin/sh\n"
-	      "echo device=/dev/sdf\n"
-	      "echo label=sdf-label\n"
-	      "echo mount-point=sdf-mount-point\n", fp);
+	fputs(SHEBANG_ECHO "\n\
+device=/dev/sdf", fp);
 	fclose(fp);
 
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
@@ -110,34 +110,38 @@ TEST(menu_is_loaded)
 TEST(entries_are_formatted_correctly)
 {
 	FILE *fp = fopen("script", "w");
-	fputs("#!/bin/sh\n"
-	      "echo device=/dev/label-1mount\n"
-	      "echo label=label\n"
-	      "echo mount-point=mount-point\n"
-	      "echo\n"
-	      "echo device=/dev/nolabel-nomount\n"
-	      ""
-	      "echo device=/dev/label-2mounts\n"
-	      "echo mount-point=mount-point1\n"
-	      "echo mount-point=mount-point2\n"
-	      "echo label=otherlabel\n", fp);
+	fputs(SHEBANG_ECHO "\n\
+device=/dev/label-1mount\n\
+label=ignored label\n\
+label=label\n\
+garbage lines\n\n\n\n\
+mount-point=mount-point\n\
+device=/dev/nolabel-nomount\n\
+\n\
+device=/dev/label-2mounts\n\
+mount-point=mount-point1\n\
+mount-point=mount-point2\n\
+mount-point=mount-point3\n\
+label=ignored label\n\
+info=device info [my label]\n", fp);
 	fclose(fp);
 
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
 
-	assert_int_equal(9, menu_get_current()->len);
+	assert_int_equal(10, menu_get_current()->len);
 
 	assert_string_equal("/dev/label-1mount [label]",
 			menu_get_current()->items[0]);
-	assert_string_equal("  -- mount-point", menu_get_current()->items[1]);
+	assert_string_equal("`-- mount-point", menu_get_current()->items[1]);
 	assert_string_equal("", menu_get_current()->items[2]);
-	assert_string_equal("/dev/nolabel-nomount", menu_get_current()->items[3]);
-	assert_string_equal("  -- not mounted", menu_get_current()->items[4]);
+	assert_string_equal("/dev/nolabel-nomount ", menu_get_current()->items[3]);
+	assert_string_equal("`-- (not mounted)", menu_get_current()->items[4]);
 	assert_string_equal("", menu_get_current()->items[5]);
-	assert_string_equal("/dev/label-2mounts [otherlabel]",
+	assert_string_equal("/dev/label-2mounts device info [my label]",
 			menu_get_current()->items[6]);
-	assert_string_equal("  -- mount-point1", menu_get_current()->items[7]);
-	assert_string_equal("  -- mount-point2", menu_get_current()->items[8]);
+	assert_string_equal("|-- mount-point1", menu_get_current()->items[7]);
+	assert_string_equal("|-- mount-point2", menu_get_current()->items[8]);
+	assert_string_equal("`-- mount-point3", menu_get_current()->items[9]);
 	assert_string_equal(NULL, menu_get_current()->data[0]);
 	assert_string_equal("umount-point", menu_get_current()->data[1]);
 	assert_string_equal(NULL, menu_get_current()->data[2]);
@@ -147,31 +151,17 @@ TEST(entries_are_formatted_correctly)
 	assert_string_equal(NULL, menu_get_current()->data[6]);
 	assert_string_equal("umount-point1", menu_get_current()->data[7]);
 	assert_string_equal("umount-point2", menu_get_current()->data[8]);
-}
+	assert_string_equal("umount-point3", menu_get_current()->data[9]);
 
-TEST(enter_does_nothing_on_non_mount_line)
-{
-	FILE *fp = fopen("script", "w");
-	fputs("#!/bin/sh\n"
-	      "echo device=/dev/sdf\n"
-	      "echo label=sdf-label\n"
-	      "echo mount-point=sdf-mount-point\n", fp);
-	fclose(fp);
-
-	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
-
-	lwin.curr_dir[0] = '\0';
-	(void)vle_keys_exec(WK_CR);
-	assert_string_equal("", lwin.curr_dir);
+	(void)vle_keys_exec(WK_ESC);
 }
 
 TEST(enter_navigates_to_mount_point)
 {
 	FILE *fp = fopen("script", "w");
-	fprintf(fp, "#!/bin/sh\n"
-	            "echo device=/dev/sdf\n"
-	            "echo label=sdf-label\n"
-	            "echo mount-point=%s\n", sandbox);
+	fprintf(fp, SHEBANG_ECHO "\n\
+device=/dev/sdf\n\
+mount-point=%s\n", sandbox);
 	fclose(fp);
 
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
@@ -182,13 +172,79 @@ TEST(enter_navigates_to_mount_point)
 	assert_true(paths_are_equal(lwin.curr_dir, sandbox));
 }
 
+TEST(enter_navigates_to_mount_point_on_device_line)
+{
+	FILE *fp = fopen("script", "w");
+	fprintf(fp, SHEBANG_ECHO "\n\
+device=/dev/sdf\n\
+mount-point=%s\n", sandbox);
+	fclose(fp);
+
+	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
+
+	lwin.curr_dir[0] = '\0';
+	(void)vle_keys_exec(WK_CR);
+	assert_true(paths_are_equal(lwin.curr_dir, sandbox));
+}
+
+TEST(enter_mounts_unmounted_device)
+{
+	FILE *fp = fopen("script", "w");
+	fputs("#!/bin/sh\n\
+echo device=/dev/sdf1\n\
+echo \"$@\" >> out\n", fp);
+	fclose(fp);
+
+	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
+
+	(void)remove("out");
+
+	/* Mounts on device line. */
+	(void)vle_keys_exec(WK_CR);
+
+	/* Mounts on "not mounted" line. */
+	(void)vle_keys_exec(WK_j);
+	(void)vle_keys_exec(WK_CR);
+
+	int nlines;
+	char **list = read_file_of_lines("out", &nlines);
+	assert_int_equal(4, nlines);
+	assert_string_equal("mount /dev/sdf1", list[0]);
+	assert_string_equal("list",            list[1]);
+	assert_string_equal("mount /dev/sdf1", list[2]);
+	assert_string_equal("list",            list[3]);
+
+	free_string_array(list, nlines);
+
+	(void)vle_keys_exec(WK_ESC);
+
+	assert_success(remove("out"));
+}
+
+TEST(enter_does_nothing_on_device_lines_with_multiple_mounts)
+{
+	FILE *fp = fopen("script", "w");
+	fputs(SHEBANG_ECHO "\n\
+device=/dev/sdf\n\
+label=sdf-label\n\
+mount-point=mount-point1\n\
+mount-point=mount-point2\n", fp);
+	fclose(fp);
+
+	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
+
+	lwin.curr_dir[0] = '\0';
+	(void)vle_keys_exec(WK_CR);
+	assert_string_equal("", lwin.curr_dir);
+}
+
 TEST(unhandled_key_is_ignored)
 {
 	FILE *fp = fopen("script", "w");
-	fprintf(fp, "#!/bin/sh\n"
-	            "echo device=/dev/sdf\n"
-	            "echo label=sdf-label\n"
-	            "echo mount-point=%s\n", sandbox);
+	fprintf(fp, SHEBANG_ECHO "\n\
+device=/dev/sdf\n\
+label=sdf-label\n\
+mount-point=%s\n", sandbox);
 	fclose(fp);
 
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
@@ -200,10 +256,10 @@ TEST(unhandled_key_is_ignored)
 TEST(r_reloads_list)
 {
 	FILE *fp = fopen("script", "w");
-	fprintf(fp, "#!/bin/sh\n"
-	            "echo device=/dev/sdf\n"
-	            "echo label=sdf-label\n"
-	            "echo mount-point=%s\n", sandbox);
+	fprintf(fp, SHEBANG_ECHO "\n\
+device=/dev/sdf\n\
+label=sdf-label\n\
+mount-point=%s\n", sandbox);
 	fclose(fp);
 
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
@@ -228,35 +284,76 @@ TEST(r_reloads_list)
 TEST(m_toggles_mounts)
 {
 	FILE *fp = fopen("script", "w");
-	fputs("#!/bin/sh\n"
-	      "echo device=/dev/sdf\n"
-	      "echo label=sdf-label\n"
-	      "echo mount-point=first-mp\n", fp);
+	fputs("#!/bin/sh\n\
+cat <<EOF\n\
+device=/dev/sdf1\n\
+\
+\n\
+device=/dev/sdf2\n\
+mount-point=sdf2-mp1\n\
+\n\
+device=/dev/sdf3\n\
+mount-point=sdf3-mp1\n\
+mount-point=sdf3-mp2\n\
+EOF\n\
+echo \"$@\" >> out\n", fp);
 	fclose(fp);
 
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
 
-	fp = fopen("script", "w");
-	fputs("#!/bin/sh\n"
-	      "echo device=/dev/sdf\n"
-	      "echo \"$@\" >> out\n", fp);
-	fclose(fp);
+	(void)remove("out");
 
-	/* Nothing happens for non-mountpoint line. */
+	/* Mounts on device line. */
 	(void)vle_keys_exec(WK_m);
-	assert_failure(remove("out"));
 
+	/* Mounts on "not mounted" line. */
 	(void)vle_keys_exec(WK_j);
 	(void)vle_keys_exec(WK_m);
+
+	/* Does nothing on blank lines. */
+	(void)vle_keys_exec(WK_j);
+	(void)vle_keys_exec(WK_m);
+
+	/* Unmounts on device line with single mount-point. */
+	(void)vle_keys_exec(WK_j);
+	(void)vle_keys_exec(WK_m);
+
+	/* Unmounts on (single) mount-point line. */
+	(void)vle_keys_exec(WK_j);
+	(void)vle_keys_exec(WK_m);
+
+	/* Does nothing on blank lines. */
+	(void)vle_keys_exec(WK_j);
+	(void)vle_keys_exec(WK_m);
+
+	/* Does not unmount on device line with multiple mount-points. */
+	(void)vle_keys_exec(WK_j);
+	(void)vle_keys_exec(WK_m);
+
+	/* Unmounts on mount-point lines. */
+	(void)vle_keys_exec(WK_j);
+	(void)vle_keys_exec(WK_m);
+	(void)vle_keys_exec(WK_j);
 	(void)vle_keys_exec(WK_m);
 
 	int nlines;
 	char **list = read_file_of_lines("out", &nlines);
-	assert_int_equal(4, nlines);
-	assert_string_equal("unmount first-mp", list[0]);
-	assert_string_equal("list", list[1]);
-	assert_string_equal("mount /dev/sdf", list[2]);
-	assert_string_equal("list", list[3]);
+	assert_int_equal(12, nlines);
+	assert_string_equal("mount /dev/sdf1",  list[0]);
+	assert_string_equal("list",             list[1]);
+	assert_string_equal("mount /dev/sdf1",  list[2]);
+	assert_string_equal("list",             list[3]);
+
+	assert_string_equal("unmount sdf2-mp1", list[4]);
+	assert_string_equal("list",             list[5]);
+	assert_string_equal("unmount sdf2-mp1", list[6]);
+	assert_string_equal("list",             list[7]);
+
+	assert_string_equal("unmount sdf3-mp1", list[8]);
+	assert_string_equal("list",             list[9]);
+	assert_string_equal("unmount sdf3-mp2", list[10]);
+	assert_string_equal("list",             list[11]);
+
 	free_string_array(list, nlines);
 
 	(void)vle_keys_exec(WK_ESC);
@@ -267,19 +364,18 @@ TEST(m_toggles_mounts)
 TEST(mounting_failure_is_handled)
 {
 	FILE *fp = fopen("script", "w");
-	fputs("#!/bin/sh\n"
-	      "echo device=/dev/sdf\n"
-	      "echo label=sdf-label\n"
-	      "echo mount-point=first-mp\n", fp);
+	fputs(SHEBANG_ECHO "\n\
+device=/dev/sdf\n\
+mount-point=mount-point1\n", fp);
 	fclose(fp);
 
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
 
 	fp = fopen("script", "w");
-	fputs("#!/bin/sh\n"
-	      "echo \"$@\" >> out\n"
-	      "echo Things went bad 1>&2\n"
-	      "exit 10\n", fp);
+	fputs("#!/bin/sh\n\
+echo \"$@\" >> out\n\
+echo Things went bad 1>&2\n\
+exit 10\n", fp);
 	fclose(fp);
 
 	(void)vle_keys_exec(WK_j);
@@ -288,7 +384,7 @@ TEST(mounting_failure_is_handled)
 	int nlines;
 	char **list = read_file_of_lines("out", &nlines);
 	assert_int_equal(1, nlines);
-	assert_string_equal("unmount first-mp", list[0]);
+	assert_string_equal("unmount mount-point1", list[0]);
 	free_string_array(list, nlines);
 
 	(void)vle_keys_exec(WK_ESC);
@@ -299,10 +395,10 @@ TEST(mounting_failure_is_handled)
 TEST(mount_directory_is_left_before_unmounting)
 {
 	FILE *fp = fopen("script", "w");
-	fprintf(fp, "#!/bin/sh\n"
-	            "pwd >> %s/out\n"
-	            "echo device=/dev/sdf\n"
-	            "echo mount-point=%s\n", sandbox, sandbox);
+	fprintf(fp, "#!/bin/sh\n\
+pwd >> %s/out\n\
+echo device=/dev/sdf\n\
+echo mount-point=%s\n", sandbox, sandbox);
 	fclose(fp);
 
 	free(cfg.media_prg);
@@ -336,17 +432,75 @@ TEST(mount_directory_is_left_before_unmounting)
 TEST(mount_matching_current_path_is_picked_by_default)
 {
 	FILE *fp = fopen("script", "w");
-	fprintf(fp, "#!/bin/sh\n"
-	            "echo device=/dev/sdd\n"
-	            "echo mount-point=/bla\n"
-	            "echo device=/dev/sdf\n"
-	            "echo mount-point=%s\n", sandbox);
+	fprintf(fp, SHEBANG_ECHO "\n\
+device=/dev/sdd\n\
+mount-point=/bla\n\
+device=/dev/sdf\n\
+mount-point=%s\n", sandbox);
 	fclose(fp);
 
 	strcpy(lwin.curr_dir, sandbox);
 	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
 
 	assert_int_equal(4, menu_get_current()->pos);
+
+	(void)vle_keys_exec(WK_ESC);
+}
+
+TEST(barckets_navigates_between_devices)
+{
+	FILE *fp = fopen("script", "w");
+	fputs(SHEBANG_ECHO "\n\
+device=dev\n\
+\
+\n\
+device=dev\n\
+mount-point=/\n\
+mount-point=/\n\
+mount-point=/\n\
+\n\
+device=dev\n\
+mount-point=/", fp);
+	fclose(fp);
+
+	strcpy(lwin.curr_dir, sandbox);
+	assert_success(exec_commands("media", &lwin, CIT_COMMAND));
+
+	assert_int_equal(10, menu_get_current()->len);
+
+	const int jumps_LB[] = { 0, 0, 0, 0, 3, 3, 3, 3, 3, 8 };
+	const int jumps_RB[] = { 3, 3, 3, 8, 8, 8, 8, 8, 8, 9 };
+
+#define key_exec_on_line(key, linepos) \
+	menu_get_current()->pos = linepos; \
+	(void)vle_keys_exec(WK_##key); \
+	assert_int_equal(jumps_##key[linepos], menu_get_current()->pos);
+
+	/* "["-jumps. */
+	key_exec_on_line(LB, 0);
+	key_exec_on_line(LB, 1);
+	key_exec_on_line(LB, 2);
+	key_exec_on_line(LB, 3);
+	key_exec_on_line(LB, 4);
+	key_exec_on_line(LB, 5);
+	key_exec_on_line(LB, 6);
+	key_exec_on_line(LB, 7);
+	key_exec_on_line(LB, 8);
+	key_exec_on_line(LB, 9);
+
+	/* "]"-jumps. */
+	key_exec_on_line(RB, 0);
+	key_exec_on_line(RB, 1);
+	key_exec_on_line(RB, 2);
+	key_exec_on_line(RB, 3);
+	key_exec_on_line(RB, 4);
+	key_exec_on_line(RB, 5);
+	key_exec_on_line(RB, 6);
+	key_exec_on_line(RB, 7);
+	key_exec_on_line(RB, 8);
+	key_exec_on_line(RB, 9);
+
+#undef key_exec_on_line
 
 	(void)vle_keys_exec(WK_ESC);
 }

--- a/tests/misc/menus_media.c
+++ b/tests/misc/menus_media.c
@@ -79,6 +79,18 @@ TEARDOWN()
 	curr_stats.load_stage = 0;
 }
 
+TEST(menu_not_created_if_no_devices)
+{
+	FILE *fp = fopen("script", "w");
+	fputs(SHEBANG_ECHO "\n\
+mount-point=no-device\n\
+nothing", fp);
+	fclose(fp);
+
+	assert_failure(exec_commands("media", &lwin, CIT_COMMAND));
+	assert_true(vle_mode_is(NORMAL_MODE));
+}
+
 TEST(menu_aborts_if_mediaprg_is_not_set)
 {
 	update_string(&cfg.media_prg, "");


### PR DESCRIPTION
- Spawn media program in foreground,
- Show decorators for devices and mount-points,
- Make actions to be more human-friendly in regards of selected item,
- Accept `info=` for showing arbitrary text next to devices,
- Add [, ] keybindings for navigating between devices,
- Show blank lines only if there is enough space for them.

I didn't want to pollute the code with new commands like "eject"/"detach"/"power off" with random keybindings, instead user can extend her media program and implement these functionalities in that.
So running it in foreground solves this and my password input issues too.

I kept blank lines only if there is enough rows, so they won't be annoying if other devices go off-screen because of them; otherwise they help visually separating devices (as before). Plus, I added decorators also for visual appearance.