### PR TITLE
Fix trash directory annoyances

### DIFF
--- a/src/trash.c
+++ b/src/trash.c
@@ -232,7 +232,13 @@ try_create_trash_dir(const char trash_dir[], int user_specific)
 	{
 		if(make_path(trash_dir, 0777) != 0)
 		{
+#ifndef _WIN32
+			/* Do not treat it an error if trash is not writable because
+			 * file-system is mounted read-only.  User should be aware of it. */
+			return errno != EROFS;
+#else
 			return 1;
+#endif
 		}
 	}
 

--- a/src/vifm.c
+++ b/src/vifm.c
@@ -304,9 +304,13 @@ vifm_main(int argc, char *argv[])
 	cs_write();
 	setup_signals();
 
-	/* Ensure trash directories exist, it might not have been called during
-	 * configuration file sourcing if there is no `set trashdir=...` command. */
-	(void)set_trash_dir(cfg.trash_dir);
+	if(cfg.use_trash)
+	{
+		/* Ensure trash directories exist, it might not have been called during
+		 * configuration file sourcing if there is no `set trashdir=...` command.
+		 * */
+		(void)set_trash_dir(cfg.trash_dir);
+	}
 
 	check_path_for_file(&lwin, vifm_args.lwin_path, vifm_args.lwin_handle);
 	check_path_for_file(&rwin, vifm_args.rwin_path, vifm_args.rwin_handle);


### PR DESCRIPTION
* Create trash directory only if user wants it.
* If file system is read-only, do not warn about non-creatable trash.