### PR TITLE
allow fullcontrol of find command via findprg

### DIFF
--- a/src/cfg/config.c
+++ b/src/cfg/config.c
@@ -32,6 +32,12 @@
 #define SAMPLE_VIFMRC "vifmrc-osx"
 #endif
 
+#ifdef _WIN32
+#define FIND_DEFAULT_PREDICATE "-iname"
+#else
+#define FIND_DEFAULT_PREDICATE "-name"
+#endif
+
 #include <assert.h> /* assert() */
 #include <limits.h> /* INT_MIN */
 #include <stddef.h> /* NULL size_t */
@@ -154,8 +160,9 @@ cfg_init(void)
 	cfg.filter_inverted_by_default = 1;
 
 	cfg.apropos_prg = strdup("apropos %a");
-	cfg.find_prg = strdup("find %s %a -print , "
-			"-type d \\( ! -readable -o ! -executable \\) -prune");
+	cfg.find_prg = strdup("find %s "FIND_DEFAULT_PREDICATE" %a -print , "
+  			"-type d \\( ! -readable -o ! -executable \\) -prune");
+
 	cfg.grep_prg = strdup("grep -n -H -I -r %i %a %s");
 	cfg.locate_prg = strdup("locate %a");
 	cfg.delete_prg = strdup("");

--- a/src/menus/find_menu.c
+++ b/src/menus/find_menu.c
@@ -32,11 +32,6 @@
 #include "../macros.h"
 #include "menus.h"
 
-#ifdef _WIN32
-#define DEFAULT_PREDICATE "-iname"
-#else
-#define DEFAULT_PREDICATE "-name"
-#endif
 
 static int execute_find_cb(view_t *view, menu_data_t *m);
 
@@ -86,7 +81,7 @@ show_find_menu(view_t *view, int with_path, const char args[])
 		else
 		{
 			char *const escaped_args = shell_like_escape(args, 0);
-			custom_args = format_str("%s %s", DEFAULT_PREDICATE, escaped_args);
+			custom_args = format_str("%s", escaped_args); 
 			macros[M_a].value = custom_args;
 			free(escaped_args);
 		}


### PR DESCRIPTION
ISSUE:
For the moment, although there is ability to customize the find command via "findprg", :find command always automatically populate "-name" (or "-iname" for WIN32 build). It makes difficulty for customize the find command (for example: change case sensitive behavior, use a better search util such as "fd" ...).

SUGGESTION:
vifm should not populate "-name" and give full control to user to customize findprg. the -iname/-name should be generated in default findprg only 