### PR TITLE
Add "nospace" key to 'sizefmt' option

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -1,4 +1,4 @@
-.TH VIFM 1 "July 15, 2019" "vifm 0.10.1-beta"
+.TH VIFM 1 "July 16, 2019" "vifm 0.10.1-beta"
 .\" ---------------------------------------------------------------------------
 .SH NAME
 .\" ---------------------------------------------------------------------------
@@ -4279,7 +4279,7 @@ Alternatively 0, 1 and 2 Vim-like values  are also accepted and correspond to
 .BI 'sizefmt'
 type: string list
 .br
-default: "units:iec"
+default: "units:iec,space"
 .br
 Configures the way size is formatted in human-friendly way.
 
@@ -4290,13 +4290,14 @@ Configures the way size is formatted in human-friendly way.
     precision:    i > 0         How many fraction digits to consider.
                   {not set}     Precision of 1 for integer part < 10,
                                 0 otherwise (provides old behaviour).
+    space         {boolean}     Show space before unit symbols.
 
 Numbers are rounded from zero.  Trailing zeros are dropped.
 
 Example:
 .EX
 
-  set sizefmt=units:iec,precision:2
+  set sizefmt=units:iec,precision:2,nospace
 .EE
 
 .TP

--- a/src/cfg/config.c
+++ b/src/cfg/config.c
@@ -216,6 +216,7 @@ cfg_init(void)
 	cfg.sizefmt.base = 1024;
 	cfg.sizefmt.precision = 0;
 	cfg.sizefmt.ieci_prefixes = 0;
+	cfg.sizefmt.space = 1;
 
 	cfg.pane_tabs = 0;
 	cfg.show_tab_line = STL_MULTIPLE;

--- a/src/cfg/config.h
+++ b/src/cfg/config.h
@@ -310,6 +310,8 @@ typedef struct config_t
 		int precision;     /* Number of digits after dot to consider (0 for old
 		                      behaviour). */
 		int ieci_prefixes; /* When base is 1024, whether to say KiB instead of K. */
+		int space;         /* Whether a space should be displayed between numbers
+		                      and unit symbols. */
 	}
 	sizefmt;
 

--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -404,6 +404,8 @@ static const char *milleroptions_enum[][2] = {
 static const char *sizefmt_enum[][2] = {
 	{ "units:",     "iec (1024) or si (1000) unit size" },
 	{ "precision:", "maximum width of fraction part" },
+	{ "space",      "show separator space" },
+	{ "nospace",    "hide separator space" },
 };
 
 /* Possible values of 'sort' option. */
@@ -2321,7 +2323,7 @@ sizefmt_handler(OPT_OP op, optval_t val)
 	char *const new_val = strdup(val.str_val);
 	char *part = new_val, *state = NULL;
 
-	int base = -1, precision = 0;
+	int base = -1, precision = 0, space = 1;
 
 	while((part = split_and_get(part, ',', &state)) != NULL)
 	{
@@ -2351,6 +2353,14 @@ sizefmt_handler(OPT_OP op, optval_t val)
 				break;
 			}
 		}
+		else if(strcmp(part, "space") == 0)
+		{
+			space = 1;
+		}
+		else if(strcmp(part, "nospace") == 0)
+		{
+			space = 0;
+		}
 		else
 		{
 			break_at(part, ':');
@@ -2365,6 +2375,7 @@ sizefmt_handler(OPT_OP op, optval_t val)
 	{
 		cfg.sizefmt.base = base;
 		cfg.sizefmt.precision = precision;
+		cfg.sizefmt.space = space;
 
 		curr_stats.need_update = UT_REDRAW;
 	}
@@ -2386,12 +2397,16 @@ make_sizefmt_value(void)
 	static char value[128];
 	static const optval_t val = { .str_val = value };
 
-	const int len = snprintf(value, sizeof(value), "units:%s",
+	int len = snprintf(value, sizeof(value), "units:%s",
 			cfg.sizefmt.base == 1024 ? "iec" : "si");
 	if(cfg.sizefmt.precision != 0)
 	{
-		snprintf(value + len, sizeof(value) - len, ",precision:%d",
+		len += snprintf(value + len, sizeof(value) - len, ",precision:%d",
 				cfg.sizefmt.precision);
+	}
+	if(cfg.sizefmt.space == 0)
+	{
+		len += snprintf(value + len, sizeof(value) - len, ",nospace");
 	}
 
 	return val;

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -253,12 +253,12 @@ friendly_size_notation(uint64_t num, int str_size, char str[])
 
 	if(fraction == 0)
 	{
-		snprintf(str, str_size, "%.0f %s", d, units[u]);
+		snprintf(str, str_size, "%.0f%*s%s", d, !!cfg.sizefmt.space, "", units[u]);
 	}
 	else
 	{
-		snprintf(str, str_size, "%.0f.%0*" PRINTF_ULL " %s", d, fraction_width,
-				fraction, units[u]);
+		snprintf(str, str_size, "%.0f.%0*" PRINTF_ULL "%*s%s", d, fraction_width,
+				fraction, !!cfg.sizefmt.space, "", units[u]);
 	}
 
 	return u > 0U;

--- a/tests/fileops/suite.c
+++ b/tests/fileops/suite.c
@@ -34,6 +34,7 @@ SETUP_ONCE()
 	cfg.sizefmt.ieci_prefixes = 0;
 	cfg.sizefmt.base = 1024;
 	cfg.sizefmt.precision = 0;
+	cfg.sizefmt.space = 1;
 }
 
 SETUP()

--- a/tests/misc/expand_status_line_macros.c
+++ b/tests/misc/expand_status_line_macros.c
@@ -75,6 +75,7 @@ SETUP()
 	cfg.sizefmt.ieci_prefixes = 0;
 	cfg.sizefmt.base = 1024;
 	cfg.sizefmt.precision = 0;
+	cfg.sizefmt.space = 1;
 }
 
 TEARDOWN()

--- a/tests/misc/options.c
+++ b/tests/misc/options.c
@@ -410,38 +410,52 @@ TEST(sizefmt_is_set_on_correct_input)
 
 	assert_int_equal(1024, cfg.sizefmt.base);
 	assert_int_equal(0, cfg.sizefmt.precision);
+	assert_int_equal(1, cfg.sizefmt.space);
 
-	assert_success(exec_commands("set sizefmt=units:si,precision:1", &lwin,
+	assert_success(exec_commands("set sizefmt=units:si,precision:1,space", &lwin,
 				CIT_COMMAND));
 
 	assert_int_equal(1000, cfg.sizefmt.base);
 	assert_int_equal(1, cfg.sizefmt.precision);
+	assert_int_equal(1, cfg.sizefmt.space);
+
+	assert_success(exec_commands("set sizefmt=units:iec,precision:2,nospace", &lwin,
+				CIT_COMMAND));
+
+	assert_int_equal(1024, cfg.sizefmt.base);
+	assert_int_equal(2, cfg.sizefmt.precision);
+	assert_int_equal(0, cfg.sizefmt.space);
 }
 
 TEST(sizefmt_not_changed_on_wrong_input)
 {
 	cfg.sizefmt.base = -1;
 	cfg.sizefmt.precision = -1;
+	cfg.sizefmt.space = -1;
 
 	assert_failure(exec_commands("set sizefmt=wrong", &lwin, CIT_COMMAND));
 	assert_failure(exec_commands("set sizefmt=units:wrong", &lwin, CIT_COMMAND));
 	assert_failure(exec_commands("set sizefmt=precision:0", &lwin, CIT_COMMAND));
+	assert_failure(exec_commands("set sizefmt=precision:,units:si", &lwin, CIT_COMMAND));
+	assert_failure(exec_commands("set sizefmt=space", &lwin, CIT_COMMAND));
+	assert_failure(exec_commands("set sizefmt=nospace", &lwin, CIT_COMMAND));
 
 	assert_int_equal(-1, cfg.sizefmt.base);
 	assert_int_equal(-1, cfg.sizefmt.precision);
+	assert_int_equal(-1, cfg.sizefmt.space);
 }
 
 TEST(values_in_sizefmt_are_deduplicated)
 {
 	(void)replace_string(&cfg.border_filler, "x");
 
-	assert_success(exec_commands("set sizefmt=units:si", &lwin, CIT_COMMAND));
-	assert_success(exec_commands("set sizefmt+=units:iec,precision:10", &lwin,
+	assert_success(exec_commands("set sizefmt=units:si,space", &lwin, CIT_COMMAND));
+	assert_success(exec_commands("set sizefmt+=nospace,units:iec,precision:10", &lwin,
 				CIT_COMMAND));
 
 	vle_tb_clear(vle_err);
 	assert_success(vle_opts_set("sizefmt?", OPT_GLOBAL));
-	assert_string_equal("  sizefmt=units:iec,precision:10",
+	assert_string_equal("  sizefmt=units:iec,precision:10,nospace",
 			vle_tb_get_data(vle_err));
 }
 

--- a/tests/utils/friendly_size.c
+++ b/tests/utils/friendly_size.c
@@ -9,6 +9,7 @@ SETUP()
 	cfg.sizefmt.ieci_prefixes = 0;
 	cfg.sizefmt.base = 1024;
 	cfg.sizefmt.precision = 0;
+	cfg.sizefmt.space = 1;
 }
 
 TEST(removing_useless_trailing_zero)
@@ -123,6 +124,30 @@ TEST(huge_precision)
 	friendly_size_notation(231093, sizeof(buf), buf);
 	assert_true(starts_with_lit(buf, "225.676757812"));
 	assert_true(ends_with(buf, " K"));
+}
+
+TEST(nospace)
+{
+	char buf[16];
+
+	cfg.sizefmt.ieci_prefixes = 1;
+	cfg.sizefmt.precision = 0;
+	cfg.sizefmt.space = 0;
+
+	friendly_size_notation(10301024, sizeof(buf), buf);
+	assert_string_equal("10MiB", buf);
+}
+
+TEST(nospace_with_precision)
+{
+	char buf[16];
+
+	cfg.sizefmt.ieci_prefixes = 1;
+	cfg.sizefmt.precision = 2;
+	cfg.sizefmt.space = 0;
+
+	friendly_size_notation(10301024, sizeof(buf), buf);
+	assert_string_equal("9.83MiB", buf);
 }
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */


### PR DESCRIPTION
Makes inserted space optional when formatting sizes, ie. `9.2 M` => `9.2M`.