### PR TITLE
Reset decoration cache on change

### DIFF
--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -1662,20 +1662,11 @@ classify_handler(OPT_OP op, optval_t val)
 
 	if(str_to_classify(val.str_val, type_decs) == 0)
 	{
-		int i;
-
 		assert(sizeof(cfg.type_decs) == sizeof(type_decs) && "Arrays diverged");
 		memcpy(&cfg.type_decs, &type_decs, sizeof(cfg.type_decs));
 
-		/* Reset cached indexes for name-dependent type_decs. */
-		for(i = 0; i < lwin.list_rows; ++i)
-		{
-			lwin.dir_entry[i].name_dec_num = -1;
-		}
-		for(i = 0; i < rwin.list_rows; ++i)
-		{
-			rwin.dir_entry[i].name_dec_num = -1;
-		}
+		ui_view_reset_decor_cache(&lwin);
+		ui_view_reset_decor_cache(&rwin);
 
 		/* 'classify' option affects columns layout, hence views must be reloaded as
 		 * loading list of files performs calculation of filename properties. */

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -1657,6 +1657,27 @@ ui_get_decors(const dir_entry_t *entry, const char **prefix,
 	}
 }
 
+void
+ui_view_reset_decor_cache(const view_t *view)
+{
+	int i;
+
+	for(i = 0; i < view->list_rows; ++i)
+	{
+		view->dir_entry[i].name_dec_num = -1;
+	}
+
+	for(i = 0; i < view->left_column.entries.nentries; ++i)
+	{
+		view->left_column.entries.entries[i].name_dec_num = -1;
+	}
+
+	for(i = 0; i < view->right_column.entries.nentries; ++i)
+	{
+		view->right_column.entries.entries[i].name_dec_num = -1;
+	}
+}
+
 /* Gets real type of file view entry.  Returns type of entry, resolving symbolic
  * link if needed. */
 static FileType

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -622,6 +622,9 @@ void format_entry_name(const dir_entry_t *entry, NameFormat fmt, size_t buf_len,
 void ui_get_decors(const dir_entry_t *entry, const char **prefix,
 		const char **suffix);
 
+/* Reset cached indexes for name-dependent type_decs. */
+void ui_view_reset_decor_cache(const view_t *view);
+
 /* Moves cursor to position specified by coordinates checking result of the
  * movement. */
 void checked_wmove(WINDOW *win, int y, int x);


### PR DESCRIPTION
Decoration index cache must be reset for every dir_entry in both views
including **left and right columns**. Although, a full reload follows
the change, it can fire redraw events (before the actual reload happens)
in some circumstances (e.g. file list change) that potentially use
invalid decoration indexes from the cache.

It was really hard to find out how I can reproduce this, because at first I was more than sure that it has to be a data race. Surely not the simplest but a stable way to reproduce:

#### Reproduction
0) Assure that you have some items in `'classify'`.
1) Open two panes L and R in split view. `set millerview` in L and focus R.
2) Execute `:write | edit $MYVIFMRC | restart<CR>` (defaults to `,c`),  add `set classify=""` at the end, and most importantly delete a file (but not all!) from the directory of pane L (open another vifm or use terminal). It should cause a file list change in the inactive pane.
3) Close your config editor.
4) Vifm should crash.
(It can be reproduced using single pane, too.)

@xaizek  Could you please add tests? Probably, you could even make test case more simpler.

_Edit: deleted word + clarified reproduction_