### PR TITLE
Fix issue #498

### DIFF
--- a/src/utils/utils_win.c
+++ b/src/utils/utils_win.c
@@ -195,35 +195,28 @@ win_exec_cmd(char cmd[], int *returned_exit_code)
 char *
 win_make_sh_cmd(const char cmd[], ShellRequester by)
 {
-	char buf[strlen(cfg.shell) + 5 + strlen(cmd)*4 + 1 + 1];
-
+	const char *sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "/C");
+  const char *fmt = 0;
 	if(curr_stats.shell_type == ST_CMD)
 	{
 		/* Documentation in `cmd /?` seems to LIE, can't make both spaces and
 		 * special characters work at the same time. */
-		const char *const fmt = (cmd[0] == '"') ? "%s %s \"%s\"" : "%s %s %s";
-		const char *sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "/C");
-		snprintf(buf, sizeof(buf), fmt, cfg.shell, sh_flag, cmd);
+		fmt = (cmd[0] == '"') ? "%s %s \"%s\"" : "%s %s %s";
 	}
 	else
 	{
-		const char *sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "/C");
-		snprintf(buf, sizeof(buf), "%s %s '", cfg.shell, sh_flag);
-
-		char *p = buf + strlen(buf);
-		while(*cmd != '\0')
-		{
-			if(*cmd == '\\')
-			{
-				*p++ = '\\';
-			}
-			*p++ = *cmd++;
-		}
-		*p = '\0';
-
-		strcat(buf, "'");
+    fmt = "%s %s \'%s\'";
 	}
-
+	// size of format minus the size of the %s-s
+  int buf_size = strlen(fmt) - 3 * 2 + \
+                    strlen(cfg.shell) + \
+                    strlen(sh_flag) + \
+                    strlen(cmd)*4 + \
+										// leading "
+                    1 + \
+                    1; // trailing "
+  char buf[buf_size];
+  snprintf(buf, sizeof(buf), fmt, cfg.shell, sh_flag, cmd);
 	return strdup(buf);
 }
 

--- a/src/utils/utils_win.c
+++ b/src/utils/utils_win.c
@@ -196,7 +196,8 @@ char *
 win_make_sh_cmd(const char cmd[], ShellRequester by)
 {
 	const char *sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "/C");
-  const char *fmt = 0;
+
+	const char *fmt;
 	if(curr_stats.shell_type == ST_CMD)
 	{
 		/* Documentation in `cmd /?` seems to LIE, can't make both spaces and
@@ -205,18 +206,18 @@ win_make_sh_cmd(const char cmd[], ShellRequester by)
 	}
 	else
 	{
-    fmt = "%s %s \'%s\'";
+		fmt = "%s %s \'%s\'";
 	}
-	// size of format minus the size of the %s-s
-  int buf_size = strlen(fmt) - 3 * 2 + \
-                    strlen(cfg.shell) + \
-                    strlen(sh_flag) + \
-                    strlen(cmd)*4 + \
-										// leading "
-                    1 + \
-                    1; // trailing "
-  char buf[buf_size];
-  snprintf(buf, sizeof(buf), fmt, cfg.shell, sh_flag, cmd);
+
+	/* Size of format minus the size of the %s-s. */
+	int buf_size = strlen(fmt) - 3*2
+	             + strlen(cfg.shell)
+	             + strlen(sh_flag)
+	             + strlen(cmd)*4
+	             + 1  /* Leading ". */
+	             + 1; /* Trailing ". */
+	char buf[buf_size];
+	snprintf(buf, sizeof(buf), fmt, cfg.shell, sh_flag, cmd);
 	return strdup(buf);
 }
 

--- a/src/utils/utils_win.c
+++ b/src/utils/utils_win.c
@@ -196,6 +196,7 @@ char *
 win_make_sh_cmd(const char cmd[], ShellRequester by)
 {
 	const char *sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "/C");
+	char *free_me = NULL;
 
 	const char *fmt;
 	if(curr_stats.shell_type == ST_CMD)
@@ -207,6 +208,20 @@ win_make_sh_cmd(const char cmd[], ShellRequester by)
 	else
 	{
 		fmt = "%s %s \'%s\'";
+
+		free_me = malloc(strlen(cmd)*2 + 1);
+		char *p = free_me;
+		while(*cmd != '\0')
+		{
+			if(*cmd == '\\')
+			{
+				*p++ = '\\';
+			}
+			*p++ = *cmd++;
+		}
+		*p = '\0';
+
+		cmd = free_me;
 	}
 
 	/* Size of format minus the size of the %s-s. */
@@ -217,6 +232,7 @@ win_make_sh_cmd(const char cmd[], ShellRequester by)
 	             + 1; /* Trailing '\0'. */
 	char buf[buf_size];
 	snprintf(buf, sizeof(buf), fmt, cfg.shell, sh_flag, cmd);
+	free(free_me);
 	return strdup(buf);
 }
 

--- a/src/utils/utils_win.c
+++ b/src/utils/utils_win.c
@@ -213,9 +213,8 @@ win_make_sh_cmd(const char cmd[], ShellRequester by)
 	int buf_size = strlen(fmt) - 3*2
 	             + strlen(cfg.shell)
 	             + strlen(sh_flag)
-	             + strlen(cmd)*4
-	             + 1  /* Leading ". */
-	             + 1; /* Trailing ". */
+	             + strlen(cmd)
+	             + 1; /* Trailing '\0'. */
 	char buf[buf_size];
 	snprintf(buf, sizeof(buf), fmt, cfg.shell, sh_flag, cmd);
 	return strdup(buf);

--- a/src/utils/utils_win.c
+++ b/src/utils/utils_win.c
@@ -195,18 +195,20 @@ win_exec_cmd(char cmd[], int *returned_exit_code)
 char *
 win_make_sh_cmd(const char cmd[], ShellRequester by)
 {
-	const char *sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "/C");
+	const char *sh_flag;
 	char *free_me = NULL;
 
 	const char *fmt;
 	if(curr_stats.shell_type == ST_CMD)
 	{
+		sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "/C");
 		/* Documentation in `cmd /?` seems to LIE, can't make both spaces and
 		 * special characters work at the same time. */
 		fmt = (cmd[0] == '"') ? "%s %s \"%s\"" : "%s %s %s";
 	}
 	else
 	{
+		sh_flag = (by == SHELL_BY_USER ? cfg.shell_cmd_flag : "-c");
 		fmt = "%s %s \'%s\'";
 
 		free_me = malloc(strlen(cmd)*2 + 1);


### PR DESCRIPTION
Include the actual size of the command flag in the size of the
buffer. Also simplified the code between the different cases.

Unfortunately I have not been able to test this, it compiles but
does not link using MXE on WSL, a MSYS2 build also fails.