### PR TITLE
Provide AppImage build on each tag/release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ addons:
   apt:
     packages:
     - python-pip
+    - build-essential
+    - automake
+    - autoconf
   coverity_scan:
     project:
       name: vifm/vifm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,72 +1,56 @@
 language: c
-
 jobs:
   include:
-    - os: linux
-      compiler: gcc
-    - os: linux
-      compiler: clang
-    # gcc is just a link to clang on OS X so no need to run it without
-    # sanitizers
-    - os: osx
-      compiler: gcc
-      env: CONFIGURE_EXTRA=--with-sanitize=basic
-    - os: osx
-      compiler: clang
-
+  - os: linux
+    compiler: gcc
+  - os: linux
+    compiler: clang
+  - os: osx
+    compiler: gcc
+    env: CONFIGURE_EXTRA=--with-sanitize=basic
+  - os: osx
+    compiler: clang
 env:
   global:
-    - secure: "Ejc9hqPE/TQ1HiSao3FHZ8piTmpCVuQthPYUuFv8Yz7GDbia7yx85b9IHd17wVmg1rGHaFed9hvSesbfFu82h86NYLmnQJGvA4XAptpBw8Z3621U0ar2QXHuaY7uAaKdeAC5NwIS6/DiufEqGtQJrNNs+5pLEATGOuoO+QugdTI="
-
+  - secure: Ejc9hqPE/TQ1HiSao3FHZ8piTmpCVuQthPYUuFv8Yz7GDbia7yx85b9IHd17wVmg1rGHaFed9hvSesbfFu82h86NYLmnQJGvA4XAptpBw8Z3621U0ar2QXHuaY7uAaKdeAC5NwIS6/DiufEqGtQJrNNs+5pLEATGOuoO+QugdTI=
 addons:
   apt:
     packages:
-      - python-pip
+    - python-pip
   coverity_scan:
     project:
       name: vifm/vifm
       version: 0.11+
-      description: "TUI file manager with vi like key bindings."
+      description: TUI file manager with vi like key bindings.
     notification_email: xaizek@posteo.net
     build_command_prepend: scripts/fix-timestamps fast && ./configure --disable-dependency-tracking
     build_command: make -j 3
     branch_pattern: coverity-scan
-
 cache:
-  - pip
-
+- pip
 script:
- - if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then
-     scripts/fix-timestamps fast && (
-       if [ "$CC" = gcc -a "$TRAVIS_OS_NAME" = linux ]; then
-         pip install --user cpp-coveralls pyopenssl ndg-httpsclient pyasn1 &&
-         ./configure --disable-dependency-tracking --enable-coverage;
-       else
-         ./configure --disable-dependency-tracking $CONFIGURE_EXTRA;
-       fi
-     ) &&
-     make -j4 &&
-     make check &&
-     (
-         if [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG" ]; then
-         ./pkgs/AppImage/genappimage.sh && 
-         curl -OL https://github.com/probonopd/uploadtool/raw/master/upload.sh && 
-         UPLOADTOOL_SUFFIX="$TRAVIS_TAG" bash upload.sh "vifm-$(arch).AppImage";
-       fi
-     );
-   fi
-
+- if [ "$COVERITY_SCAN_BRANCH" != 1 ]; then scripts/fix-timestamps fast && ( if [
+  "$CC" = gcc -a "$TRAVIS_OS_NAME" = linux ]; then pip install --user cpp-coveralls
+  pyopenssl ndg-httpsclient pyasn1 && ./configure --disable-dependency-tracking --enable-coverage;
+  else ./configure --disable-dependency-tracking $CONFIGURE_EXTRA; fi ) && make -j4
+  && make check && ( if [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG"
+  ]; then ./pkgs/AppImage/genappimage.sh && curl -OL https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  && UPLOADTOOL_SUFFIX="$TRAVIS_TAG" bash upload.sh "vifm-$(arch).AppImage"; fi );
+  fi
 after_success:
- - if [ "$COVERITY_SCAN_BRANCH" != 1 -a "$CC" = gcc ]; then
-     coveralls --encoding iso-8859-1 --build-root src/
-                                     --exclude tests
-                                     --exclude src/lua/lua
-                                     --exclude src/utils/parson.c
-                                     --exclude src/utils/xxhash.c
-                                     --gcov-options '\-p';
-   fi
-
+- if [ "$COVERITY_SCAN_BRANCH" != 1 -a "$CC" = gcc ]; then coveralls --encoding iso-8859-1
+  --build-root src/ --exclude tests --exclude src/lua/lua --exclude src/utils/parson.c
+  --exclude src/utils/xxhash.c --gcov-options '\-p'; fi
 notifications:
   email:
     recipients:
-      - xaizek@posteo.net
+    - xaizek@posteo.net
+deploy:
+  provider: releases
+  api_key:
+    secure: OdkPjORbqrdIX8uy8RptWUa5AeTsU+ilnAhg6G8s+zf6zdQUcTU7aANK9l8BjtC63MNBWPt6dNvlyjEZzomWnaisn+ikS27HBt2gMecewybAKuehe6CuAJO9eP8UyIQUbac3N1VZMsz62tEUeNaBiKwUdt0ddRErXcP52BgIc3t1Kq3BbXsFbzNaDD2a+uXQ8hcMqY5abeml7Y8+OSOoYUo30tDDpVSBKNo/K6CK//DiQREEoSqgTJ46yS82b2yjHsB03ZxIRbAwCSBzVG2Zxb8c+5djQnpN4W35unqMvjD0w1TOuYNcQ5ptMldOhOzD23ypnt4t1QHgrtSHWcVri/8Q23RkWfwT/buFz1LXFaz+P2848rIgjvtdGqjDipk2hne0LT91/VhQ8rQTB2NZbkPXV0GJnOQIDE4EFh60n/wJTad+O4cCi4ODnjDNf24xcxPNGtrXWksTk42xEtXPRvrmfGtaeeDDE5zLNkjlcRIq2wcqTszQeSPsD8WH3b7rC2+G7KHWdMHj0SJktGi/+gtgAeoxdUEFU6kewojvf0V75pQKyoNVA6RMov3LHV1PYK8ium7CuIRgmDyaltbT7PCULXBgdbzEfJ12lsJ/gcaq7w+yuRpJC3jAdWoZlzMWrzWQWLMQrPTjd09IJmXE+k8wMxR3Hu+tzsQulIZvSfA=
+  file: "vifm-$(arch).AppImage"
+  on:
+    repo: michaellee8/vifm
+    condition: [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG" ] 
+  skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
          if [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG" ]; then
          ./pkgs/AppImage/genappimage.sh && 
          curl -OL https://github.com/probonopd/uploadtool/raw/master/upload.sh && 
-         UPLOADTOOL_SUFFIX="$TRAVIS_TAG" bash upload.sh "vifm-$(arch).AppImage"
+         UPLOADTOOL_SUFFIX="$TRAVIS_TAG" bash upload.sh "vifm-$(arch).AppImage";
        fi
      );
    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,5 +51,5 @@ deploy:
   file: vifm.appimage
   on:
     tags: true
-    condition: '[ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ]'
+    condition: '("$CC" = gcc) && ("$TRAVIS_OS_NAME" = linux)'
   skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,14 @@ script:
        fi
      ) &&
      make -j4 &&
-     make check;
+     make check &&
+     (
+       if ["$CC" = gcc -a "TRAVIS_OS_NAME" = linux -a -n "$TRAVIS_TAG"]; then
+         ./pkgs/AppImage/genappimage.sh && 
+         curl -OL https://github.com/probonopd/uploadtool/raw/master/upload.sh && 
+         UPLOADTOOL_SUFFIX="$TRAVIS_TAG" bash upload.sh "vifm-$(arch).AppImage"
+       fi
+     );
    fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,6 @@ deploy:
     secure: OdkPjORbqrdIX8uy8RptWUa5AeTsU+ilnAhg6G8s+zf6zdQUcTU7aANK9l8BjtC63MNBWPt6dNvlyjEZzomWnaisn+ikS27HBt2gMecewybAKuehe6CuAJO9eP8UyIQUbac3N1VZMsz62tEUeNaBiKwUdt0ddRErXcP52BgIc3t1Kq3BbXsFbzNaDD2a+uXQ8hcMqY5abeml7Y8+OSOoYUo30tDDpVSBKNo/K6CK//DiQREEoSqgTJ46yS82b2yjHsB03ZxIRbAwCSBzVG2Zxb8c+5djQnpN4W35unqMvjD0w1TOuYNcQ5ptMldOhOzD23ypnt4t1QHgrtSHWcVri/8Q23RkWfwT/buFz1LXFaz+P2848rIgjvtdGqjDipk2hne0LT91/VhQ8rQTB2NZbkPXV0GJnOQIDE4EFh60n/wJTad+O4cCi4ODnjDNf24xcxPNGtrXWksTk42xEtXPRvrmfGtaeeDDE5zLNkjlcRIq2wcqTszQeSPsD8WH3b7rC2+G7KHWdMHj0SJktGi/+gtgAeoxdUEFU6kewojvf0V75pQKyoNVA6RMov3LHV1PYK8ium7CuIRgmDyaltbT7PCULXBgdbzEfJ12lsJ/gcaq7w+yuRpJC3jAdWoZlzMWrzWQWLMQrPTjd09IJmXE+k8wMxR3Hu+tzsQulIZvSfA=
   file: vifm.appimage
   on:
-    repo: michaellee8/vifm
-    condition: '[ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG" ]' 
+    tags: true
+    condition: '[ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ]'
   skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ script:
   pyopenssl ndg-httpsclient pyasn1 && ./configure --disable-dependency-tracking --enable-coverage;
   else ./configure --disable-dependency-tracking $CONFIGURE_EXTRA; fi ) && make -j4
   && make check && ( if [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG"
-  ]; then ./pkgs/AppImage/genappimage.sh && curl -OL https://github.com/probonopd/uploadtool/raw/master/upload.sh
-  && UPLOADTOOL_SUFFIX="$TRAVIS_TAG" bash upload.sh "vifm-$(arch).AppImage"; fi );
+  ]; then ./pkgs/AppImage/genappimage.sh; fi );
   fi
 after_success:
 - if [ "$COVERITY_SCAN_BRANCH" != 1 -a "$CC" = gcc ]; then coveralls --encoding iso-8859-1
@@ -49,8 +48,8 @@ deploy:
   provider: releases
   api_key:
     secure: OdkPjORbqrdIX8uy8RptWUa5AeTsU+ilnAhg6G8s+zf6zdQUcTU7aANK9l8BjtC63MNBWPt6dNvlyjEZzomWnaisn+ikS27HBt2gMecewybAKuehe6CuAJO9eP8UyIQUbac3N1VZMsz62tEUeNaBiKwUdt0ddRErXcP52BgIc3t1Kq3BbXsFbzNaDD2a+uXQ8hcMqY5abeml7Y8+OSOoYUo30tDDpVSBKNo/K6CK//DiQREEoSqgTJ46yS82b2yjHsB03ZxIRbAwCSBzVG2Zxb8c+5djQnpN4W35unqMvjD0w1TOuYNcQ5ptMldOhOzD23ypnt4t1QHgrtSHWcVri/8Q23RkWfwT/buFz1LXFaz+P2848rIgjvtdGqjDipk2hne0LT91/VhQ8rQTB2NZbkPXV0GJnOQIDE4EFh60n/wJTad+O4cCi4ODnjDNf24xcxPNGtrXWksTk42xEtXPRvrmfGtaeeDDE5zLNkjlcRIq2wcqTszQeSPsD8WH3b7rC2+G7KHWdMHj0SJktGi/+gtgAeoxdUEFU6kewojvf0V75pQKyoNVA6RMov3LHV1PYK8ium7CuIRgmDyaltbT7PCULXBgdbzEfJ12lsJ/gcaq7w+yuRpJC3jAdWoZlzMWrzWQWLMQrPTjd09IJmXE+k8wMxR3Hu+tzsQulIZvSfA=
-  file: "vifm-$(arch).AppImage"
+  file: vifm.appimage
   on:
     repo: michaellee8/vifm
-    condition: [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG" ] 
+    condition: '[ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG" ]' 
   skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   "$CC" = gcc -a "$TRAVIS_OS_NAME" = linux ]; then pip install --user cpp-coveralls
   pyopenssl ndg-httpsclient pyasn1 && ./configure --disable-dependency-tracking --enable-coverage;
   else ./configure --disable-dependency-tracking $CONFIGURE_EXTRA; fi ) && make -j4
-  && make check && ( if [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG"
+  && make check && ( if [ "$CC" = clang ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG"
   ]; then ./pkgs/AppImage/genappimage.sh; fi );
   fi
 after_success:
@@ -51,5 +51,5 @@ deploy:
   file: vifm.appimage
   on:
     tags: true
-    condition: '("$CC" = gcc) && ("$TRAVIS_OS_NAME" = linux)'
+    condition: '("$CC" = clang) && ("$TRAVIS_OS_NAME" = linux)'
   skip_cleanup: 'true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
      make -j4 &&
      make check &&
      (
-       if ["$CC" = gcc -a "TRAVIS_OS_NAME" = linux -a -n "$TRAVIS_TAG"]; then
+         if [ "$CC" = gcc ] && [ "$TRAVIS_OS_NAME" = linux ] && [ -n "$TRAVIS_TAG" ]; then
          ./pkgs/AppImage/genappimage.sh && 
          curl -OL https://github.com/probonopd/uploadtool/raw/master/upload.sh && 
          UPLOADTOOL_SUFFIX="$TRAVIS_TAG" bash upload.sh "vifm-$(arch).AppImage"

--- a/data/metainfo/vifm.appdata.xml
+++ b/data/metainfo/vifm.appdata.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+	<id>vifm</id>
+	<metadata_license>CC0-1.0</metadata_license>
+	<project_license>GPL-2.0+</project_license>
+	<name>vifm</name>
+	<summary>vifm - vi[m] like file manager</summary>
+	<description>
+		<p>Vifm is a curses based vi[m] like file manager extended with some useful ideas from mutt. If you use vi[m], vifm gives you complete keyboard control over your files without having to learn a new set of commands. It goes not just about vi[m] like keybindings, but also about modes, options, registers, commands and other things you might already like in vi[m].
+
+Just like vi[m], vifm tries to adhere to the Unix philosophy. So instead of working solutions which are set in stone user is provided with a set of means for customization of vifm to one's likings. Though builtin functionality should be enough for most of use cases.</p>
+	</description>
+	<launchable type="desktop-id">vifm.desktop</launchable>
+	<url type="homepage">https://vifm.info/</url>
+	<provides>
+		<id>vifm.desktop</id>
+	</provides>
+</component>

--- a/data/metainfo/vifm.appdata.xml
+++ b/data/metainfo/vifm.appdata.xml
@@ -12,6 +12,11 @@ Just like vi[m], vifm tries to adhere to the Unix philosophy. So instead of work
 	</description>
 	<launchable type="desktop-id">vifm.desktop</launchable>
 	<url type="homepage">https://vifm.info/</url>
+	<screenshot type="default">
+		<image>
+			https://raw.githubusercontent.com/vifm/vifm/master/data/graphics/screenshot.png
+		</image>	
+	</screenshot>
 	<provides>
 		<id>vifm.desktop</id>
 	</provides>

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -x
 set -e
 

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# Contributed by michaellee8 <ckmichael8@gmail.com> in 2020
+
 set -x
 set -e
 

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -1,0 +1,69 @@
+#! /bin/bash
+
+set -x
+set -e
+
+# Reference: https://docs.appimage.org/packaging-guide/from-source/native-binaries.html#id2
+
+# building in temporary directory to keep system clean
+# use RAM disk if possible (as in: not building on CI system 
+# like Travis, and RAM disk is available)
+if [ "$CI" == "" ] && [ -d /dev/shm ]; then
+    TEMP_BASE=/dev/shm
+else
+    TEMP_BASE=/tmp
+fi
+
+BUILD_DIR=$(mktemp -d -p "$TEMP_BASE" appimage-build-XXXXXX)
+
+# make sure to clean up build dir, even if errors occur
+cleanup () {
+    if [ -d "$BUILD_DIR" ]; then
+        rm -rf "$BUILD_DIR"
+    fi
+}
+trap cleanup EXIT
+
+# store repo root as variable
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+OLD_CWD=$(readlink -f .)
+
+mkdir "$BUILD_DIR/AppDir"
+
+# Install to the corresponding AppDir
+# It is assumed that this script runs after a successful make only
+
+make DESTDIR="$BUILD_DIR/AppDir" install
+
+# Since the make script produce binaries to /usr/local to default, we need to 
+# make it /usr so linuxdeploy will recognize it.
+
+pushd "$BUILD_DIR"
+
+pushd AppDir
+
+mv usr/local .
+rm -r usr
+mv local usr
+
+# Downloading linuxdeploy
+
+curl -o ./linuxdeploy -L \
+    https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+
+chmod +x ./linuxdeploy
+
+# Custom AppRun to provide $ARGV0 issues when used with zsh
+# Reference: https://github.com/neovim/neovim/blob/master/scripts/genappimage.sh
+# Reference: https://github.com/neovim/neovim/issues/9341
+
+cat << 'EOF' > AppRun
+#!/bin/bash
+unset ARGV0
+exec "$(dirname "$(readlink  -f "${0}")")/usr/bin/nvim" ${@+"$@"}
+EOF
+chmod 755 AppRun
+
+popd
+
+./linuxdeploy --appdir AppDir --output appimage

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -60,7 +60,8 @@ cp -r "$REPO_ROOT/data/metainfo" "$BUILD_DIR/AppDir/usr/share/"
 # Reference: https://github.com/neovim/neovim/blob/master/scripts/genappimage.sh
 # Reference: https://github.com/neovim/neovim/issues/9341
 
-cat << 'EOF' > "$BUILD_DIR/AppDir/AppRun"
+cd $BUILD_DIR
+cat << 'EOF' > AppDir/AppRun
 #!/bin/bash
 unset ARGV0
 exec "$(dirname "$(readlink  -f "${0}")")/usr/bin/vifm" ${@+"$@"}

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -66,7 +66,7 @@ cat << 'EOF' > AppDir/AppRun
 unset ARGV0
 exec "$(dirname "$(readlink  -f "${0}")")/usr/bin/vifm" ${@+"$@"}
 EOF
-chmod 755 AppRun
+chmod 755 AppDir/AppRun
 
 
 # Downloading linuxdeploy

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -71,6 +71,6 @@ curl -o ./linuxdeploy -L \
 
 chmod +rx ./linuxdeploy
 
-OUTPUT="vifm-$(arch).AppImage" ./linuxdeploy --appdir ./AppDir --output appimage
+OUTPUT="vifm.appimage" ./linuxdeploy --appdir ./AppDir --output appimage
 
-mv "vifm-$(arch).AppImage" "$OLD_CWD"
+mv "vifm.appimage" "$OLD_CWD"

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -22,7 +22,7 @@ cleanup () {
         rm -rf "$BUILD_DIR"
     fi
 }
-# trap cleanup EXIT
+trap cleanup EXIT
 
 # store repo root as variable
 REPO_ROOT="$(git rev-parse --show-toplevel)"

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -42,6 +42,7 @@ make install
 popd
 
 ## Configure vifm now to make sure it uses our libncursesw6
+export LD_LIBRARY_PATH="$BUILD_DIR/AppDir/usr/lib"
 autoreconf -f -i
 autoconf
 export CPPFLAGS="-I$BUILD_DIR/AppDir/usr/include -I$BUILD_DIR/AppDir/usr/include/ncursesw" 

--- a/pkgs/AppImage/genappimage.sh
+++ b/pkgs/AppImage/genappimage.sh
@@ -64,6 +64,7 @@ cd $BUILD_DIR
 cat << 'EOF' > AppDir/AppRun
 #!/bin/bash
 unset ARGV0
+export TERMINFO=$APPDIR/usr/share/terminfo
 exec "$(dirname "$(readlink  -f "${0}")")/usr/bin/vifm" ${@+"$@"}
 EOF
 chmod 755 AppDir/AppRun


### PR DESCRIPTION
It took me a day to finally get latest version to put this up together. It is tested to work with distro as old as Ubuntu 16.04 LTS. I have manually compiled libncursesw6 so that it will work even for 256 colors terminals (like xterm-256color). It also uses its own terminfo database so theoretically it should work as long as there are libc, for example alpine linux.

Note that you will need to changed the deploy section with your own encrypted key and maybe other things to work in your repo.