### PR TITLE
Add keybindings to permissions dialog

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -6012,6 +6012,16 @@ One shortcut per sorting key (see the dialog).
 h, Space \- check/uncheck.
 .br
 q \- close dialog
+.br
+r \- (*nix only) (un)set all read bits
+.br
+w \- (*nix only) (un)set all write bits
+.br
+x \- (*nix only) (un)set all execute bits
+.br
+x \- (*nix only) (un)set all special (SetUID, SetGID, Sticky) bits
+.br
+e \- (*nix only) (un)set recursion (for directories only)
 
 Item states:
 .IP \- 2

--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -6019,7 +6019,7 @@ w \- (*nix only) (un)set all write bits
 .br
 x \- (*nix only) (un)set all execute bits
 .br
-x \- (*nix only) (un)set all special (SetUID, SetGID, Sticky) bits
+s \- (*nix only) (un)set all special (SetUID, SetGID, Sticky) bits
 .br
 e \- (*nix only) (un)set recursion (for directories only)
 

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -5075,6 +5075,11 @@ Attributes (permissions or properties) dialog~
 
 h, Space - check/uncheck.
 q - close dialog
+r - (*nix only) (un)set all read bits
+w - (*nix only) (un)set all write bits
+x - (*nix only) (un)set all execute bits
+s - (*nix only) (un)set all special (SetUID, SetGID, Sticky) bits
+e - (*nix only) (un)set recursion (for directories only)
 
 Item states:
 * - checked flag.

--- a/src/modes/dialogs/attr_dialog_nix.c
+++ b/src/modes/dialogs/attr_dialog_nix.c
@@ -71,7 +71,7 @@ static void cmd_r(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_w(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_x(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_s(key_info_t key_info, keys_info_t *keys_info);
-static void cmd_recurse(key_info_t key_info, keys_info_t *keys_info);
+static void cmd_e(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_j(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_k(key_info_t key_info, keys_info_t *keys_info);
 static void inc_curr(void);
@@ -110,7 +110,7 @@ static keys_add_info_t builtin_cmds[] = {
 	{WK_w,      {{&cmd_w},      .descr = "toggle write bits"}},
 	{WK_x,      {{&cmd_x},      .descr = "toggle execute bits"}},
 	{WK_s,      {{&cmd_s},      .descr = "toggle special bits"}},
-	{WK_e,      {{&cmd_recurse},.descr = "toggle recursion"}},
+	{WK_e,      {{&cmd_e},      .descr = "toggle recursion"}},
 #ifdef ENABLE_EXTENDED_KEYS
 	{{K(KEY_HOME)},  {{&cmd_gg},     .descr = "go to the first item"}},
 	{{K(KEY_END)},   {{&cmd_G},      .descr = "go to the last item"}},
@@ -597,7 +597,7 @@ cmd_s(key_info_t key_info, keys_info_t *keys_info)
 }
 
 static void
-cmd_recurse(key_info_t key_info, keys_info_t *keys_info)
+cmd_e(key_info_t key_info, keys_info_t *keys_info)
 {
 	if (file_is_dir)
 	{


### PR DESCRIPTION
I implemented keybindings to set/unset all the bits of a same class in the permission dialog (as requested #659). Namely, `r` sets/unsets all the r bits, and so on. Also `e` checks the "Set Recursively" flag.

I added some comments in some other parts of the file. Since I did not notice comments in that file, feel free to remove them, but I think they are somehow helpful.

Let me know in case there is something I overlooked or that I can improve. I have neither access to nor familiarity with Windows so those are for Unix only.