### PR TITLE
Add %v for vertical multiplexer split

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -3298,20 +3298,23 @@ Same as %u, but implies less list updates inside vifm, which is absence of
 sorting at the moment.
 .TP
 .BI %Iu
-same as %u, but gives up terminal before running external command.
+Same as %u, but gives up terminal before running external command.
 .TP
 .BI %IU
-same as %U, but gives up terminal before running external command.
+Same as %U, but gives up terminal before running external command.
 .TP
 .BI %S
 Show command output in the status bar.
 .TP
 .BI %q
-redirect command output to quick view, which is activated if disabled.
+Redirect command output to quick view, which is activated if disabled.
 .TP
 .BI %s
-Execute command in split window of active terminal multiplexer (ignored if not
-running inside one).
+Execute command in horizontally split window of active terminal multiplexer
+(ignored if not running inside one).
+.TP
+.BI %v
+Same as %s, but splits vertically.
 .TP
 .BI %n
 Forbid using of terminal multiplexer to run the command.

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -2727,8 +2727,10 @@ The command macros may be used in user commands.
   %q        redirect command output to quick view, which is activated if
             disabled.
                                                                *vifm-%s*
-  %s        execute command in split window of active terminal
+  %s        execute command in horizontally split window of active terminal
             multiplexer (ignored if not running inside one).
+                                                               *vifm-%v*
+  %v        same as %s, but splits vertically.
                                                                *vifm-%n*
   %n        forbid using of terminal multiplexer to run the command.
                                                                *vifm-%i*

--- a/src/macros.c
+++ b/src/macros.c
@@ -275,8 +275,11 @@ expand_macros_i(const char command[], const char args[], MacroFlags *flags,
 			case 'q': /* Show command output in the preview */
 				set_flags(flags, MF_PREVIEW_OUTPUT);
 				break;
-			case 's': /* Split in new screen region and execute command there. */
+			case 's': /* Horizontally split in new screen region and execute command there. */
 				set_flags(flags, MF_SPLIT);
+				break;
+			case 'v': /* Vertically split in new screen region and execute command there. */
+				set_flags(flags, MF_SPLIT_VERT);
 				break;
 			case 'u': /* Parse output as list of files and compose custom view. */
 				set_flags(flags, MF_CUSTOMVIEW_OUTPUT);
@@ -817,6 +820,7 @@ ma_flags_to_str(MacroFlags flags)
 		case MF_VERYCUSTOMVIEW_IOUTPUT: return "%IU";
 
 		case MF_SPLIT: return "%s";
+		case MF_SPLIT_VERT: return "%v";
 		case MF_IGNORE: return "%i";
 		case MF_NO_TERM_MUX: return "%n";
 	}

--- a/src/macros.h
+++ b/src/macros.h
@@ -42,7 +42,8 @@ typedef enum
 	MF_CUSTOMVIEW_IOUTPUT,     /* Applying current sorting. */
 	MF_VERYCUSTOMVIEW_IOUTPUT, /* Not changing ordering. */
 
-	MF_SPLIT,       /* Run command in a new screen region. */
+	MF_SPLIT,       /* Run command in a new horizontally split screen region. */
+	MF_SPLIT_VERT,  /* Run command in a new vertically split screen region. */
 	MF_IGNORE,      /* Completely ignore command output. */
 	MF_NO_TERM_MUX, /* Forbid using terminal multiplexer, even if active. */
 }

--- a/tests/misc/expand_macros.c
+++ b/tests/misc/expand_macros.c
@@ -279,6 +279,11 @@ TEST(good_flag_macros)
 	assert_string_equal(" echo log", expanded);
 	assert_int_equal(MF_VERYCUSTOMVIEW_OUTPUT, flags);
 	free(expanded);
+
+	expanded = ma_expand("%v echo log", "", &flags, 0);
+	assert_string_equal(" echo log", expanded);
+	assert_int_equal(MF_SPLIT_VERT, flags);
+	free(expanded);
 }
 
 TEST(bad_flag_macros)


### PR DESCRIPTION
Vifm has the `%s` macro, but this always splits horizontally. For a vertically split window, I propose `%v`.

I have tested the patch both in Screen and Tmux. 

Let me know if there is something I can improve. Cheers!