### PR TITLE
Allow file count before tree in quickview

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -4306,6 +4306,7 @@ view mode).
   item               default  meaning
   graphicsdelay:num  0        delay before drawing graphics (microseconds)
   hardgraphicsclear  unset    redraw screen to get rid of graphics
+  toptreestats       unset    show file counts before the tree in quick view
 
 graphicsdelay is needed if terminal requires some timeout before it can
 draw graphics (otherwise it gets lost).

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -3605,6 +3605,7 @@ view mode).
     item               default  meaning ~
     graphicsdelay:num  0        delay before drawing graphics (microseconds)
     hardgraphicsclear  unset    redraw screen to get rid of graphics
+    toptreestats       unset    show file counts before the tree in quick view
 
 graphicsdelay is needed if terminal requires some timeout before it can
 draw graphics (otherwise it gets lost).

--- a/src/cfg/config.c
+++ b/src/cfg/config.c
@@ -194,6 +194,7 @@ cfg_init(void)
 
 	cfg.graphics_delay = 50000;
 	cfg.hard_graphics_clear = 0;
+	cfg.top_tree_stats = 0;
 
 	cfg.timeout_len = 1000;
 	cfg.min_timeout_len = 150;

--- a/src/cfg/config.h
+++ b/src/cfg/config.h
@@ -299,6 +299,8 @@ typedef struct config_t
 	int graphics_delay;
 	/* Redraw screen to get rid of graphics. */
 	int hard_graphics_clear;
+	/* Show file counts on top of the tree */
+	int top_tree_stats;
 
 	int timeout_len;     /* Maximum period on waiting for the input. */
 	int min_timeout_len; /* Minimum period on waiting for the input. */

--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -335,6 +335,7 @@ static const char *lsoptions_enum[][2] = {
 static const char *previewoptions_vals[][2] = {
 	{ "graphicsdelay:",    "delay before drawing graphics" },
 	{ "hardgraphicsclear", "redraw screen to get rid of graphics" },
+	{ "toptreestats",      "show file counts on top of the tree" },
 };
 
 /* Possible values of 'suggestoptions'. */
@@ -1176,18 +1177,22 @@ init_millerview(optval_t *val)
 static void
 init_previewoptions(optval_t *val)
 {
-	static char buf[64];
+	static char buf[128];
 
 	size_t len = 0U;
 	buf[0] = '\0';
 
 	if(cfg.hard_graphics_clear)
 	{
-		(void)sstrappend(buf, &len, sizeof(buf), "hardgraphicsclear");
+		(void)sstrappend(buf, &len, sizeof(buf), "hardgraphicsclear,");
+	}
+	if(cfg.top_tree_stats)
+	{
+		(void)sstrappend(buf, &len, sizeof(buf), "toptreestats,");
 	}
 	if(cfg.graphics_delay != 0)
 	{
-		snprintf(buf + len, sizeof(buf) - len, "graphicsdelay:%d",
+		snprintf(buf + len, sizeof(buf) - len, "graphicsdelay:%d,",
 				cfg.graphics_delay);
 	}
 
@@ -2285,6 +2290,7 @@ previewoptions_handler(OPT_OP op, optval_t val)
 
 	int graphics_delay = 0;
 	int hard_graphics_clear = 0;
+	int top_tree_stats = 0;
 
 	while((part = split_and_get(part, ',', &state)) != NULL)
 	{
@@ -2308,6 +2314,10 @@ previewoptions_handler(OPT_OP op, optval_t val)
 		{
 			hard_graphics_clear = 1;
 		}
+		else if(strcmp(part, "toptreestats") == 0)
+		{
+			top_tree_stats = 1;
+		}
 		else
 		{
 			break_at(part, ':');
@@ -2322,6 +2332,10 @@ previewoptions_handler(OPT_OP op, optval_t val)
 	{
 		cfg.graphics_delay = graphics_delay;
 		cfg.hard_graphics_clear = hard_graphics_clear;
+		if(top_tree_stats != cfg.top_tree_stats) {
+			text_option_changed();
+		}
+		cfg.top_tree_stats = top_tree_stats;
 	}
 
 	/* In case of error, restore previous value, otherwise reload it anyway to

--- a/tests/misc/options.c
+++ b/tests/misc/options.c
@@ -732,11 +732,13 @@ TEST(previewoptions)
 				CIT_COMMAND));
 	assert_int_equal(12345, cfg.graphics_delay);
 	assert_false(cfg.hard_graphics_clear);
+	assert_false(cfg.top_tree_stats);
 
 	assert_failure(exec_commands("set previewoptions=graphicsdelay:inf", &lwin,
 				CIT_COMMAND));
 	assert_int_equal(12345, cfg.graphics_delay);
 	assert_false(cfg.hard_graphics_clear);
+	assert_false(cfg.top_tree_stats);
 	assert_string_equal("Failed to parse \"graphicsdelay\" value: inf",
 			vle_tb_get_data(vle_err));
 
@@ -744,6 +746,7 @@ TEST(previewoptions)
 				CIT_COMMAND));
 	assert_int_equal(12345, cfg.graphics_delay);
 	assert_false(cfg.hard_graphics_clear);
+	assert_false(cfg.top_tree_stats);
 	assert_string_equal("\"graphicsdelay\" can't be negative, got: -12345",
 			vle_tb_get_data(vle_err));
 
@@ -751,6 +754,7 @@ TEST(previewoptions)
 				&lwin, CIT_COMMAND));
 	assert_int_equal(12345, cfg.graphics_delay);
 	assert_false(cfg.hard_graphics_clear);
+	assert_false(cfg.top_tree_stats);
 	assert_string_equal("Unknown key for 'previewoptions' option: wtf",
 			vle_tb_get_data(vle_err));
 
@@ -758,10 +762,18 @@ TEST(previewoptions)
 				CIT_COMMAND));
 	assert_int_equal(0, cfg.graphics_delay);
 	assert_true(cfg.hard_graphics_clear);
+	assert_false(cfg.top_tree_stats);
+
+	assert_success(exec_commands("set previewoptions=toptreestats", &lwin,
+				CIT_COMMAND));
+	assert_true(cfg.top_tree_stats);
+	assert_int_equal(0, cfg.graphics_delay);
+	assert_false(cfg.hard_graphics_clear);
 
 	assert_success(exec_commands("set previewoptions=", &lwin, CIT_COMMAND));
 	assert_int_equal(0, cfg.graphics_delay);
 	assert_false(cfg.hard_graphics_clear);
+	assert_false(cfg.top_tree_stats);
 }
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */


### PR DESCRIPTION
This is meant to address issue #514 with a new boolean option, `countfirst`, which allows one to move the count of directory and non-directory files to the top of the quick view when listing a directory. 

Handling the cache part was a bit challenging for me, so, as usual, please let me know if there is something to improve. Cheers!