### PR TITLE
Updated vi[x]cmd for Windows

### DIFF
--- a/data/vifmrc
+++ b/data/vifmrc
@@ -377,7 +377,7 @@ filextype */
 " For OS X:
 " filetype * open
 " For Windows:
-" filetype * start, explorer
+" filetype * start, explorer %"f &
 
 " ------------------------------------------------------------------------------
 


### PR DESCRIPTION
When opening files in Windows10 by hitting enter, I get a noticeable lag even for 1KB text file which doesn't happen when opening from Windows Explorer. This happens with stock vifmrc only on Windows10 but not on Windows7.
Also when opening a file the console window goes blank (black console background is shown when vifm was running) on both win10 and win7.

Adding `%"f &` after explorer in the option fixes both the aforementioned problems for me in Win7 and Win10.

Thanks for making vifm and making it available for Windows!