### PR TITLE
Make :compare honor filters

### DIFF
--- a/src/filtering.c
+++ b/src/filtering.c
@@ -297,7 +297,7 @@ filters_invert(view_t *view)
 }
 
 int
-filters_file_is_visible(view_t *view, const char dir[], const char name[],
+filters_file_is_visible(const view_t *view, const char dir[], const char name[],
 		int is_dir, int apply_local_filter)
 {
 	/* FIXME: some very long file names won't be matched against some regexps. */

--- a/src/filtering.h
+++ b/src/filtering.h
@@ -51,7 +51,7 @@ void filters_dir_updated(struct view_t *view);
 /* Checks whether file/directory passes filename filters of the view.  Returns
  * non-zero if given name passes filters and should be visible, otherwise zero
  * is returned, in which case the file should be hidden. */
-int filters_file_is_visible(struct view_t *view, const char dir[],
+int filters_file_is_visible(const struct view_t *view, const char dir[],
 		const char name[], int is_dir, int apply_local_filter);
 
 /* Dot filter related functions. */

--- a/src/utils/filter.c
+++ b/src/utils/filter.c
@@ -227,7 +227,7 @@ escape_name_for_filter(const char string[])
 }
 
 int
-filter_matches(filter_t *filter, const char pattern[])
+filter_matches(const filter_t *filter, const char pattern[])
 {
 	if(filter->is_regex_valid)
 	{

--- a/src/utils/filter.h
+++ b/src/utils/filter.h
@@ -75,7 +75,7 @@ int filter_append(filter_t *filter, const char value[]);
 /* Checks whether pattern matches the filter.  Returns positive number on match,
  * zero on no match and negative number on empty or invalid regular expression
  * (wrong state of the filter). */
-int filter_matches(filter_t *filter, const char pattern[]);
+int filter_matches(const filter_t *filter, const char pattern[]);
 
 #endif /* VIFM__UTILS__FILTER_H__ */
 


### PR DESCRIPTION
I think there is no need to update documentation this time since it already says

> Filtered files are not checked in / search or :commands.

Closes #683.