### PR TITLE
Use $XDG_DATA_HOME

### DIFF
--- a/src/int/file_magic.c
+++ b/src/int/file_magic.c
@@ -282,8 +282,17 @@ get_handlers(const char mime_type[])
 	parse_app_dir("/usr/local/share/applications", mime_type, &handlers);
 
 	char local_dir[PATH_MAX + 1];
-	build_path(local_dir, sizeof(local_dir), cfg.home_dir,
-			".local/share/applications");
+	char const *xdgdatahome = getenv("XDG_DATA_HOME");
+	if(xdgdatahome != NULL && *xdgdatahome)
+	{
+		build_path(local_dir, sizeof(local_dir), xdgdatahome,
+				"applications");
+	}
+	else
+	{
+		build_path(local_dir, sizeof(local_dir), cfg.home_dir,
+				".local/share/applications");
+	}
 	parse_app_dir(local_dir, mime_type, &handlers);
 #endif
 


### PR DESCRIPTION
According to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html),

> $XDG_DATA_HOME defines the base directory relative to which user-specific data files should be stored. If $XDG_DATA_HOME is either not set or empty, a default equal to $HOME/.local/share should be used. 