### PR TITLE
Add hborder

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -4051,11 +4051,16 @@ Sets characters used to fill borders.
 
   item         default    used for
   vborder:c    ' '        left, middle and right vertical borders
+  hborder:c    ''         middle horizontal border
 
-If value is omitted, its default value is used.  Example:
+A null string for vborder is equivalent to a space.
+
+A null string for hborder omits the horizontal border.
+
+Example:
+
 .EX
-
-  set fillchars=vborder:.
+  set fillchars=vborder:".",hborder:""
 .EE
 .TP
 .BI 'findprg'
@@ -5115,7 +5120,7 @@ are visible.
 .br
 u \- use Unicode characters in the TUI (Unicode ellipsis instead of "...").
 .br
-v \- vary width of middle border to equalize view sizes.
+v \- vary width of vertical middle border to equalize view sizes.
 
 Each pane title contains the path of the listed directory.  If too large, the
 path is truncated on the left for the active pane and on the right for the other

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -3369,9 +3369,14 @@ Sets characters used to fill borders.
 
     item          default         used for ~
     vborder:c     ' '             left, middle and right vertical borders
+    hborder:c     ''              middle horizontal border
 
-If value is omitted, its default value is used.  Example: >
-    set fillchars=vborder:.
+A null string for vborder is equivalent to a space.
+
+A null string for hborder omits the horizontal border.
+
+Example: >
+    set fillchars=vborder:".",hborder:""
 <
                                                *vifm-'findprg'*
 findprg
@@ -4303,7 +4308,7 @@ are visible.
                                                *vifm-to-u*
 u - use Unicode characters in the TUI (Unicode ellipsis instead of "...").
                                                *vifm-to-v*
-v - vary width of middle border to equalize view sizes.
+v - vary width of middle vertical border to equalize view sizes.
 
 Each pane title contains the path of the listed directory.  If too large, the
 path is truncated on the left for the active pane and on the right for the other

--- a/src/cfg/config.c
+++ b/src/cfg/config.c
@@ -189,7 +189,8 @@ cfg_init(void)
 	cfg.flexible_splitter = 1;
 	cfg.display_statusline = 1;
 
-	cfg.border_filler = strdup(" ");
+	cfg.vborder_filler = strdup(" ");
+	cfg.hborder_filler = strdup("");
 
 	cfg.set_title = term_title_restorable();
 

--- a/src/cfg/config.h
+++ b/src/cfg/config.h
@@ -296,7 +296,8 @@ typedef struct config_t
 	int display_statusline;
 
 	/* Per line pattern for borders. */
-	char *border_filler;
+	char *vborder_filler;
+	char *hborder_filler;
 
 	/* Whether terminal title should be updated or not. */
 	int set_title;

--- a/src/cfg/info.c
+++ b/src/cfg/info.c
@@ -2225,11 +2225,9 @@ store_global_options(JSON_Object *root)
 	append_dstr(options, format_str("deleteprg=%s",
 				escape_spaces(cfg.delete_prg)));
 	append_dstr(options, format_str("%sfastrun", cfg.fast_run ? "" : "no"));
-	if(strcmp(cfg.border_filler, " ") != 0)
-	{
-		append_dstr(options, format_str("fillchars+=vborder:%s",
-					escape_spaces(cfg.border_filler)));
-	}
+	append_dstr(options, format_str("fillchars+=vborder:%s,hborder:%s",
+				escape_spaces(cfg.vborder_filler),
+				escape_spaces(cfg.hborder_filler)));
 	append_dstr(options, format_str("findprg=%s", escape_spaces(cfg.find_prg)));
 	append_dstr(options, format_str("%sfollowlinks",
 				cfg.follow_links ? "" : "no"));

--- a/tests/misc/options.c
+++ b/tests/misc/options.c
@@ -370,34 +370,37 @@ TEST(sorting_is_set_correctly_on_restart)
 
 TEST(fillchars_is_set_on_correct_input)
 {
-	(void)replace_string(&cfg.border_filler, "x");
-	assert_success(exec_commands("set fillchars=vborder:a", &lwin, CIT_COMMAND));
-	assert_string_equal("a", cfg.border_filler);
-	update_string(&cfg.border_filler, NULL);
+	(void)replace_string(&cfg.vborder_filler, "x");
+	(void)replace_string(&cfg.hborder_filler, "y");
+	assert_success(exec_commands("set fillchars=vborder:a,hborder:b", &lwin, CIT_COMMAND));
+	assert_string_equal("a", cfg.vborder_filler);
+	assert_string_equal("b", cfg.hborder_filler);
+	update_string(&cfg.vborder_filler, NULL);
+	update_string(&cfg.hborder_filler, NULL);
 }
 
 TEST(fillchars_not_changed_on_wrong_input)
 {
-	(void)replace_string(&cfg.border_filler, "x");
+	(void)replace_string(&cfg.vborder_filler, "x");
 	assert_failure(exec_commands("set fillchars=vorder:a", &lwin, CIT_COMMAND));
-	assert_string_equal("x", cfg.border_filler);
-	update_string(&cfg.border_filler, NULL);
+	assert_string_equal("x", cfg.vborder_filler);
+	update_string(&cfg.vborder_filler, NULL);
 }
 
 TEST(values_in_fillchars_are_deduplicated)
 {
-	(void)replace_string(&cfg.border_filler, "x");
+	(void)replace_string(&cfg.vborder_filler, "x");
 
 	assert_success(exec_commands("set fillchars=vborder:a", &lwin, CIT_COMMAND));
 	assert_success(exec_commands("set fillchars+=vborder:b", &lwin, CIT_COMMAND));
-	assert_string_equal("b", cfg.border_filler);
-	update_string(&cfg.border_filler, NULL);
+	assert_string_equal("b", cfg.vborder_filler);
+	update_string(&cfg.vborder_filler, NULL);
 
 	vle_tb_clear(vle_err);
 	assert_success(vle_opts_set("fillchars?", OPT_GLOBAL));
-	assert_string_equal("  fillchars=vborder:b", vle_tb_get_data(vle_err));
+	assert_string_equal("  fillchars=vborder:b,hborder:", vle_tb_get_data(vle_err));
 
-	update_string(&cfg.border_filler, NULL);
+	update_string(&cfg.vborder_filler, NULL);
 }
 
 TEST(sizefmt_is_set_on_correct_input)
@@ -449,7 +452,7 @@ TEST(sizefmt_not_changed_on_wrong_input)
 
 TEST(values_in_sizefmt_are_deduplicated)
 {
-	(void)replace_string(&cfg.border_filler, "x");
+	(void)replace_string(&cfg.vborder_filler, "x");
 
 	assert_success(exec_commands("set sizefmt=units:si,space", &lwin, CIT_COMMAND));
 	assert_success(exec_commands("set sizefmt+=nospace,units:iec,precision:10", &lwin,

--- a/tests/test-support/test-utils.c
+++ b/tests/test-support/test-utils.c
@@ -94,7 +94,8 @@ conf_setup(void)
 	update_string(&cfg.grep_prg, "");
 	update_string(&cfg.locate_prg, "");
 	update_string(&cfg.media_prg, "");
-	update_string(&cfg.border_filler, "");
+	update_string(&cfg.vborder_filler, "");
+	update_string(&cfg.hborder_filler, "");
 	update_string(&cfg.tab_prefix, "");
 	update_string(&cfg.tab_label, "");
 	update_string(&cfg.tab_suffix, "");
@@ -128,7 +129,8 @@ conf_teardown(void)
 	update_string(&cfg.grep_prg, NULL);
 	update_string(&cfg.locate_prg, NULL);
 	update_string(&cfg.media_prg, NULL);
-	update_string(&cfg.border_filler, NULL);
+	update_string(&cfg.vborder_filler, NULL);
+	update_string(&cfg.hborder_filler, NULL);
 	update_string(&cfg.tab_prefix, NULL);
 	update_string(&cfg.tab_label, NULL);
 	update_string(&cfg.tab_suffix, NULL);


### PR DESCRIPTION
This is meant to close #712.

If you like it, I will document it.

Besides hborder, the main changes are:

1. `vborder=""` is treated equally to `vborder =" "` in `clear_border`.
2. No longer "hide" vborder from `set fillchars?` when it is null or a space. I think doing otherwise would unnecessarily complicate the code, but let me know if it's shortsight.