### PR TITLE
Added viewing of comparison results

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -6493,6 +6493,9 @@ data.
 Comparison views have second column displaying id of the file, files with same
 id are considered to be equal.  The view columns configuration is predefined.
 
+The status bar displays only the initial result of the comparison and can be
+out of date.
+
 .B Behaviour
 
 When two views are being compared against each other the following changes to

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -5497,6 +5497,9 @@ data.
 Comparison views have second column displaying id of the file, files with same
 id are considered to be equal.  The view columns configuration is predefined.
 
+The status bar displays only the initial result of the comparison and can be
+out of date.
+
 Behaviour~
 
 When two views are being compared against each other the following changes to

--- a/src/event_loop.c
+++ b/src/event_loop.c
@@ -290,6 +290,10 @@ event_loop(const int *quit, int manage_marking)
 				{
 					print_selected_msg();
 				}
+				else if(!curr_stats.save_msg && cv_compare(curr_view->custom.type))
+				{
+					print_compare_msg();
+				}
 				continue;
 			}
 		}

--- a/src/modes/modes.c
+++ b/src/modes/modes.c
@@ -43,6 +43,7 @@
 #include "normal.h"
 #include "view.h"
 #include "visual.h"
+#include "compare.h"
 
 static int mode_flags[] = {
 	MF_USES_COUNT | MF_USES_REGS, /* NORMAL_MODE */
@@ -191,6 +192,10 @@ modes_statusbar_update(void)
 			(curr_view->selected_files || vle_mode_is(VISUAL_MODE)))
 	{
 		print_selected_msg();
+	}
+	else if (!curr_stats.save_msg && cv_compare(curr_view->custom.type))
+	{
+		print_compare_msg();
 	}
 	else if(!curr_stats.save_msg)
 	{
@@ -391,6 +396,27 @@ print_selected_msg(void)
 	{
 		ui_sb_msgf("%d %s selected", curr_view->selected_files,
 				curr_view->selected_files == 1 ? "file" : "files");
+	}
+	curr_stats.save_msg = 2;
+}
+
+void
+print_compare_msg(void)
+{
+	if (curr_view->custom.diff_cmp_flags & CF_GROUP_PATHS)
+	{
+		ui_sb_msgf("Initial result: identical: %d, different: %d, unique: %d/%d",
+					curr_view->custom.diff_cmp_result.identical,
+					curr_view->custom.diff_cmp_result.different,
+					curr_view->custom.diff_cmp_result.unique_left,
+					curr_view->custom.diff_cmp_result.unique_right);
+	}
+	else
+	{
+		ui_sb_msgf("Initial result: identical: %d, unique: %d/%d",
+					curr_view->custom.diff_cmp_result.identical,
+					curr_view->custom.diff_cmp_result.unique_left,
+					curr_view->custom.diff_cmp_result.unique_right);
 	}
 	curr_stats.save_msg = 2;
 }

--- a/src/modes/modes.c
+++ b/src/modes/modes.c
@@ -30,6 +30,7 @@
 #include "../ui/ui.h"
 #include "../utils/log.h"
 #include "../utils/macros.h"
+#include "../compare.h"
 #include "../event_loop.h"
 #include "../status.h"
 #include "dialogs/attr_dialog.h"
@@ -43,7 +44,6 @@
 #include "normal.h"
 #include "view.h"
 #include "visual.h"
-#include "compare.h"
 
 static int mode_flags[] = {
 	MF_USES_COUNT | MF_USES_REGS, /* NORMAL_MODE */

--- a/src/modes/modes.h
+++ b/src/modes/modes.h
@@ -66,6 +66,8 @@ void abort_menu_like_mode(void);
 
 void print_selected_msg(void);
 
+void print_compare_msg(void);
+
 #endif /* VIFM__MODES__MODES_H__ */
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -1624,6 +1624,9 @@ ui_swap_view_data(view_t *left, view_t *right)
 	WINDOW *tmp;
 	int t;
 
+	/* Data in some fields doesn't need to be swapped.  Swap it beforehand so that
+	 * swapping structures will put it back. */
+
 	tmp = left->win;
 	left->win = right->win;
 	right->win = tmp;
@@ -1639,6 +1642,18 @@ ui_swap_view_data(view_t *left, view_t *right)
 	tmp = left->title;
 	left->title = right->title;
 	right->title = tmp;
+
+	/* Swap these fields so they reflect updated layout. */
+
+	t = left->custom.diff_cmp_result.unique_left;
+	left->custom.diff_cmp_result.unique_left =
+		left->custom.diff_cmp_result.unique_right;
+	left->custom.diff_cmp_result.unique_right = t;
+
+	t = right->custom.diff_cmp_result.unique_left;
+	right->custom.diff_cmp_result.unique_left =
+		right->custom.diff_cmp_result.unique_right;
+	right->custom.diff_cmp_result.unique_right = t;
 
 	tmp_view = *left;
 	*left = *right;

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -777,6 +777,10 @@ update_start(UpdateType update_kind)
 		{
 			print_selected_msg();
 		}
+		else if (cv_compare(curr_view->custom.type))
+		{
+			print_compare_msg();
+		}
 		else
 		{
 			ui_sb_clear();

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -254,6 +254,16 @@ typedef struct
 }
 entries_t;
 
+/* Entry with comparison results */
+typedef struct compare_result_t
+{
+	int identical;
+	int different;
+	int unique_left;
+	int unique_right;
+}
+compare_result_t;
+
 /* Data related to custom filling. */
 struct cv_data_t
 {
@@ -263,6 +273,7 @@ struct cv_data_t
 	/* Additional data about CV_DIFF type. */
 	CompareType diff_cmp_type; /* Type of comparison. */
 	int diff_cmp_flags;        /* Flags used to build the diff. */
+	compare_result_t diff_cmp_result; /* List of comparison results */
 
 	/* This is temporary storage for custom list entries used during its
 	 * construction. */


### PR DESCRIPTION
I added simple viewing of comparison results to statusbar, but after any changing of state (for example, moving cursor) this message is disappearance.
I see, that it depend on modes, so should I add new mode for it (for example, add _COMPARE_MODE_, check it into _modes_statusbar_update_ and call own _print_compare_msg_ func) or it is a bad way?

I would like to see comparing results at any time, when statusbar is empty now (no selected files, no VISUAL mode, etc.)