### PR TITLE
Comparison results selecting

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -14,7 +14,8 @@
 	columns.  Thanks to Aleksandr Vysotskiy (a.k.a. loki1368).
 
 	Added show* arguments to :compare command to control/switch which sets of
-	files are displayed.  Patch by Alexandr Keyp (a.k.a. IAmKapuze).
+	files are displayed (toggling is done by :compare!).  Patch by Alexandr
+	Keyp (a.k.a. IAmKapuze).
 
 	Reduced amount of memory consumed by `:compare groupids`.
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,9 @@
 	Added "columncount:" value to 'lsoptions' to always display fixed number of
 	columns.  Thanks to Aleksandr Vysotskiy (a.k.a. loki1368).
 
+	Added show* arguments to :compare command to control/switch which sets of
+	files are displayed.  Patch by Alexandr Keyp (a.k.a. IAmKapuze).
+
 	Reduced amount of memory consumed by `:compare groupids`.
 
 	Made `:compare bycontents` not bother reading content of files which have

--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -1,4 +1,4 @@
-.TH VIFM 1 "9 November 2022" "vifm 0.12.1"
+.TH VIFM 1 "17 November 2022" "vifm 0.12.1"
 .\" ---------------------------------------------------------------------------
 .SH NAME
 .\" ---------------------------------------------------------------------------
@@ -1745,6 +1745,12 @@ is "bycontents listall ofboth grouppaths showidentical showdifferent
 showuniqueleft showuniqueright".  See "Compare views" section below
 for details.  Diff structure is incompatible with alternative representations,
 so values of 'lsview' and 'millerview' options are ignored.
+.TP
+.BI ":compare! (showidentical | showdifferent | showuniqueleft |"
+.BI "    showuniqueright)..."
+this invocation form works only when compare view is active and results in
+redoing of the previous :compare with toggled state of the passed in
+options.
 .TP
 .BI "                                         :copen"
 .TP
@@ -6460,7 +6466,7 @@ Comparison tweaks:
  \- withicase \- ignore case when comparing file names/paths;
  \- withrcase \- respect case when comparing file names/paths.
 
-Which results to show:
+Which results to show (has no effect for single pane comparison):
  \- showidentical   \- toggle showing of identical files;
  \- showdifferent   \- toggle showing of different files;
  \- showuniqueleft  \- toggle showing of unique top/left files;

--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -1736,10 +1736,13 @@ equals
 .br
 .BI "   groupids | grouppaths |"
 .br
-.BI "   skipempty | withicase | withrcase]..."
+.BI "   skipempty | withicase | withrcase |"
+.br
+.BI "   showidentical | showdifferent | showuniqueleft | showuniqueright]..."
 .br
 compare files in one or two views according to the arguments.  The default
-is "bycontents listall ofboth grouppaths".  See "Compare views" section below
+is "bycontents listall ofboth grouppaths showidentical showdifferent
+showuniqueleft showuniqueright".  See "Compare views" section below
 for details.  Diff structure is incompatible with alternative representations,
 so values of 'lsview' and 'millerview' options are ignored.
 .TP
@@ -6426,7 +6429,7 @@ grouping to preserve as all file ids are guaranteed to be distinct.
 
 .B Creation
 
-Arguments passed to :compare form four categories each with its own
+Arguments passed to :compare form seven categories each with its own
 prefix and is responsible for particular property of operation.
 
 Which files to compare:
@@ -6457,6 +6460,12 @@ Comparison tweaks:
  \- withicase \- ignore case when comparing file names/paths;
  \- withrcase \- respect case when comparing file names/paths.
 
+Which results to show:
+ \- showidentical   \- toggle showing of identical files;
+ \- showdifferent   \- toggle showing of different files;
+ \- showuniqueleft  \- toggle showing of unique top/left files;
+ \- showuniqueright \- toggle showing of unique bottom/right files.
+
 Each argument can appear multiple times, the rightmost one of the group is
 considered.  Arguments alter default behaviour instead of substituting it.
 
@@ -6472,6 +6481,7 @@ files in two trees with grouping by paths, so the following are equivalent:
   :compare
   :compare bycontents grouppaths
   :compare bycontents listall ofboth grouppaths
+  :compare showidentical showdifferent showuniqueleft showuniqueright
 .EE
 
 Another use case is to find duplicates in the current sub-tree:

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -1,4 +1,4 @@
-*vifm-app.txt*    For Vifm version 0.12.1  Last change: 2022 Nov 9
+*vifm-app.txt*    For Vifm version 0.12.1  Last change: 2022 Nov 17
 
  Email for bugs and suggestions: <xaizek@posteo.net>
 
@@ -1511,6 +1511,11 @@ The builtin commands are:
     showuniqueleft showuniqueright".  See |vifm-compare-views| for
     details.  Diff structure is incompatible with alternative representations,
     so values of |vifm-'lsview'| and |vifm-'millerview'| options are ignored.
+:compare! (showidentical | showdifferent | showuniqueleft |
+           showuniqueright)...
+    this invocation form works only when compare view is active and results in
+    redoing of the previous :compare with toggled state of the passed in
+    options.
 
 :cope[n]                                       *vifm-:copen* *vifm-:cope*
     reopens the last visible menu that has navigation to files by default, if
@@ -5469,7 +5474,7 @@ Comparison tweaks:
  - withicase - ignore case when comparing file names/paths;
  - withrcase - respect case when comparing file names/paths.
 
-Which results to show:
+Which results to show (has no effect for single pane comparison):
  - showidentical   - toggle showing of identical files;
  - showdifferent   - toggle showing of different files;
  - showuniqueleft  - toggle showing of unique top/left files;

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -1504,9 +1504,11 @@ The builtin commands are:
           listall | listunique | listdups |
           ofboth | ofone |
           groupids | grouppaths |
-          skipempty | withicase | withrcase]...
+          skipempty | withicase | withrcase |
+          showidentical | showdifferent | showuniqueleft | showuniqueright]...
     compare files in one or two views according to the arguments.  The default
-    is "bycontents listall ofboth grouppaths".  See |vifm-compare-views| for
+    is "bycontents listall ofboth grouppaths showidentical showdifferent
+    showuniqueleft showuniqueright".  See |vifm-compare-views| for
     details.  Diff structure is incompatible with alternative representations,
     so values of |vifm-'lsview'| and |vifm-'millerview'| options are ignored.
 
@@ -5436,7 +5438,7 @@ grouping to preserve as all file ids are guaranteed to be distinct.
 
 Creation~
 
-Arguments passed to |vifm-:compare| form four categories each with its own
+Arguments passed to |vifm-:compare| form seven categories each with its own
 prefix and is responsible for particular property of operation.
 
 Which files to compare:
@@ -5467,6 +5469,12 @@ Comparison tweaks:
  - withicase - ignore case when comparing file names/paths;
  - withrcase - respect case when comparing file names/paths.
 
+Which results to show:
+ - showidentical   - toggle showing of identical files;
+ - showdifferent   - toggle showing of different files;
+ - showuniqueleft  - toggle showing of unique top/left files;
+ - showuniqueright - toggle showing of unique bottom/right files.
+
 Each argument can appear multiple times, the rightmost one of the group is
 considered.  Arguments alter default behaviour instead of substituting it.
 
@@ -5481,6 +5489,7 @@ files in two trees with grouping by paths, so the following are equivalent: >
  :compare
  :compare bycontents grouppaths
  :compare bycontents listall ofboth grouppaths
+ :compare showidentical showdifferent showuniqueleft showuniqueright
 
 Another use case is to find duplicates in the current sub-tree: >
 

--- a/src/cmd_completion.c
+++ b/src/cmd_completion.c
@@ -519,24 +519,29 @@ static void
 complete_compare(const char str[])
 {
 	static const char *lines[][2] = {
-		{ "byname",     "compare by file name" },
-		{ "bysize",     "compare by file size" },
-		{ "bycontents", "compare by file size and hash" },
+		{ "byname",          "compare by file name" },
+		{ "bysize",          "compare by file size" },
+		{ "bycontents",      "compare by file size and hash" },
 
-		{ "ofboth",     "use files of two views" },
-		{ "ofone",      "use files of two current view only" },
+		{ "ofboth",          "use files of two views" },
+		{ "ofone",           "use files of two current view only" },
 
-		{ "listall",    "list all files" },
-		{ "listunique", "list only unique files" },
-		{ "listdups",   "list only duplicated files" },
+		{ "listall",         "list all files" },
+		{ "listunique",      "list only unique files" },
+		{ "listdups",        "list only duplicated files" },
 
-		{ "groupids",   "group files in two panes by ids" },
-		{ "grouppaths", "group files in two panes by paths" },
+		{ "groupids",        "group files in two panes by ids" },
+		{ "grouppaths",      "group files in two panes by paths" },
 
-		{ "skipempty",  "exclude empty files from comparison" },
+		{ "skipempty",       "exclude empty files from comparison" },
 
-		{ "withicase",  "force ignoring case on comparing names" },
-		{ "withrcase",  "force respecting case on comparing names" },
+		{ "showidentical",   "toggle identical files viewing into comparison" },
+		{ "showdifferent",   "toggle different files viewing into comparison" },
+		{ "showuniqueleft",  "toggle unique left files viewing into comparison" },
+		{ "showuniqueright", "toggle unique right files viewing into comparison" },
+
+		{ "withicase",       "force ignoring case on comparing names" },
+		{ "withrcase",       "force respecting case on comparing names" },
 	};
 
 	complete_from_string_list(str, lines, ARRAY_LEN(lines), 0);

--- a/src/cmd_handlers.c
+++ b/src/cmd_handlers.c
@@ -2060,17 +2060,32 @@ parse_compare_properties(const cmd_info_t *cmd_info, CompareType *ct,
 	for(i = 0; i < cmd_info->argc; ++i)
 	{
 		const char *const property = cmd_info->argv[i];
+
 		if     (strcmp(property, "byname") == 0)     *ct = CT_NAME;
 		else if(strcmp(property, "bysize") == 0)     *ct = CT_SIZE;
 		else if(strcmp(property, "bycontents") == 0) *ct = CT_CONTENTS;
+
 		else if(strcmp(property, "listall") == 0)    *lt = LT_ALL;
 		else if(strcmp(property, "listunique") == 0) *lt = LT_UNIQUE;
 		else if(strcmp(property, "listdups") == 0)   *lt = LT_DUPS;
+
 		else if(strcmp(property, "ofboth") == 0)     *single_pane = 0;
 		else if(strcmp(property, "ofone") == 0)      *single_pane = 1;
+
 		else if(strcmp(property, "groupids") == 0)   *flags &= ~CF_GROUP_PATHS;
 		else if(strcmp(property, "grouppaths") == 0) *flags |= CF_GROUP_PATHS;
+
 		else if(strcmp(property, "skipempty") == 0)  *flags |= CF_SKIP_EMPTY;
+
+		else if(strcmp(property, "showidentical") == 0)
+			*flags |= CF_SHOW_IDENTICAL;
+		else if(strcmp(property, "showdifferent") == 0)
+			*flags |= CF_SHOW_DIFFERENT;
+		else if(strcmp(property, "showuniqueleft") == 0)
+			*flags |= CF_SHOW_UNIQUE_LEFT;
+		else if(strcmp(property, "showuniqueright") == 0)
+			*flags |= CF_SHOW_UNIQUE_RIGHT;
+
 		else if(strcmp(property, "withicase") == 0)
 		{
 			*flags &= ~CF_RESPECT_CASE;
@@ -2081,6 +2096,7 @@ parse_compare_properties(const cmd_info_t *cmd_info, CompareType *ct,
 			*flags &= ~CF_IGNORE_CASE;
 			*flags |= CF_RESPECT_CASE;
 		}
+
 		else
 		{
 			ui_sb_errf("Unknown comparison property: %s", property);

--- a/src/cmd_handlers.c
+++ b/src/cmd_handlers.c
@@ -154,7 +154,7 @@ static int command_cmd(const cmd_info_t *cmd_info);
 static int compare_cmd(const cmd_info_t *cmd_info);
 static int copen_cmd(const cmd_info_t *cmd_info);
 static int parse_compare_properties(const cmd_info_t *cmd_info, CompareType *ct,
-		ListType *lt, int *single_pane, int *flags);
+		ListType *lt, int *flags);
 static int cunmap_cmd(const cmd_info_t *cmd_info);
 static int delete_cmd(const cmd_info_t *cmd_info);
 static int delmarks_cmd(const cmd_info_t *cmd_info);
@@ -2030,13 +2030,13 @@ compare_cmd(const cmd_info_t *cmd_info)
 {
 	CompareType ct = CT_CONTENTS;
 	ListType lt = LT_ALL;
-	int single_pane = 0, flags = CF_GROUP_PATHS;
-	if(parse_compare_properties(cmd_info, &ct, &lt, &single_pane, &flags) != 0)
+	int flags = CF_GROUP_PATHS;
+	if(parse_compare_properties(cmd_info, &ct, &lt, &flags) != 0)
 	{
 		return CMDS_ERR_CUSTOM;
 	}
 
-	return single_pane
+	return (flags & CF_SINGLE_PANE)
 	     ? (compare_one_pane(curr_view, ct, lt, flags) != 0)
 	     : (compare_two_panes(ct, lt, flags) != 0);
 }
@@ -2054,7 +2054,7 @@ copen_cmd(const cmd_info_t *cmd_info)
  * error message is displayed on the status bar. */
 static int
 parse_compare_properties(const cmd_info_t *cmd_info, CompareType *ct,
-		ListType *lt, int *single_pane, int *flags)
+		ListType *lt, int *flags)
 {
 	int i;
 	for(i = 0; i < cmd_info->argc; ++i)
@@ -2069,8 +2069,8 @@ parse_compare_properties(const cmd_info_t *cmd_info, CompareType *ct,
 		else if(strcmp(property, "listunique") == 0) *lt = LT_UNIQUE;
 		else if(strcmp(property, "listdups") == 0)   *lt = LT_DUPS;
 
-		else if(strcmp(property, "ofboth") == 0)     *single_pane = 0;
-		else if(strcmp(property, "ofone") == 0)      *single_pane = 1;
+		else if(strcmp(property, "ofboth") == 0)     *flags &= ~CF_SINGLE_PANE;
+		else if(strcmp(property, "ofone") == 0)      *flags |= CF_SINGLE_PANE;
 
 		else if(strcmp(property, "groupids") == 0)   *flags &= ~CF_GROUP_PATHS;
 		else if(strcmp(property, "grouppaths") == 0) *flags |= CF_GROUP_PATHS;

--- a/src/compare.c
+++ b/src/compare.c
@@ -477,64 +477,59 @@ static void
 put_side_by_side_pair(dir_entry_t *curr, dir_entry_t *other, int flags,
 		compare_stats_t *stats)
 {
+	/* Integer type to avoid warning about unhandled cases in switch(). */
+	int flag;
+
 	if(other == NULL)
 	{
-		if(curr_view == &lwin)
-		{
-			stats->unique_left++;
-			if(flags & CF_SHOW_UNIQUE_LEFT)
-			{
-				flist_custom_put(curr_view, curr);
-				flist_custom_add_separator(other_view, curr->id);
-			}
-		}
-		else
-		{
-			stats->unique_right++;
-			if(flags & CF_SHOW_UNIQUE_RIGHT)
-			{
-				flist_custom_put(curr_view, curr);
-				flist_custom_add_separator(other_view, curr->id);
-			}
-		}
+		flag = (curr_view == &lwin ? CF_SHOW_UNIQUE_LEFT : CF_SHOW_UNIQUE_RIGHT);
 	}
 	else if(curr == NULL)
 	{
-		if(curr_view == &lwin)
+		flag = (other_view == &lwin ? CF_SHOW_UNIQUE_LEFT : CF_SHOW_UNIQUE_RIGHT);
+	}
+	else
+	{
+		flag = (curr->id == other->id ? CF_SHOW_IDENTICAL : CF_SHOW_DIFFERENT);
+	}
+
+	switch(flag)
+	{
+		case CF_SHOW_UNIQUE_LEFT:  ++stats->unique_left;  break;
+		case CF_SHOW_UNIQUE_RIGHT: ++stats->unique_right; break;
+		case CF_SHOW_IDENTICAL:    ++stats->identical;    break;
+		case CF_SHOW_DIFFERENT:    ++stats->different;    break;
+	}
+
+	if(flags & flag)
+	{
+		if(curr != NULL)
 		{
-			stats->unique_right++;
-			if(flags & CF_SHOW_UNIQUE_RIGHT)
-			{
-				flist_custom_put(other_view, other);
-				flist_custom_add_separator(curr_view, other->id);
-			}
+			flist_custom_put(curr_view, curr);
 		}
 		else
 		{
-			stats->unique_left++;
-			if(flags & CF_SHOW_UNIQUE_LEFT)
-			{
-				flist_custom_put(other_view, other);
-				flist_custom_add_separator(curr_view, other->id);
-			}
+			flist_custom_add_separator(curr_view, other->id);
 		}
-	}
-	else if(curr->id == other->id)
-	{
-		stats->identical++;
-		if(flags & CF_SHOW_IDENTICAL)
+
+		if(other != NULL)
 		{
-			flist_custom_put(curr_view, curr);
 			flist_custom_put(other_view, other);
+		}
+		else
+		{
+			flist_custom_add_separator(other_view, curr->id);
 		}
 	}
 	else
 	{
-		stats->different++;
-		if(flags & CF_SHOW_DIFFERENT)
+		if(curr != NULL)
 		{
-			flist_custom_put(curr_view, curr);
-			flist_custom_put(other_view, other);
+			fentry_free(curr);
+		}
+		if(other != NULL)
+		{
+			fentry_free(other);
 		}
 	}
 }

--- a/src/compare.c
+++ b/src/compare.c
@@ -121,16 +121,6 @@ compare_two_panes(CompareType ct, ListType lt, int flags)
 
 	const int group_paths = flags & CF_GROUP_PATHS;
 
-	/* If comparison is already running, toggle show* arguments. */
-	if(cv_compare(curr_view->custom.type))
-	{
-		flags ^= curr_view->custom.diff_cmp_flags & CF_SHOW;
-	}
-	else if((flags & CF_SHOW) == 0)
-	{
-		flags |= CF_SHOW;
-	}
-
 	/* We don't compare lists of files, so skip the check if at least one of the
 	 * views is a custom one. */
 	if(!flist_custom_active(&lwin) && !flist_custom_active(&rwin) &&
@@ -216,6 +206,8 @@ compare_two_panes(CompareType ct, ListType lt, int flags)
 	other_view->list_pos = 0;
 	curr_view->custom.diff_cmp_type = ct;
 	other_view->custom.diff_cmp_type = ct;
+	curr_view->custom.diff_list_type = lt;
+	other_view->custom.diff_list_type = lt;
 	curr_view->custom.diff_cmp_flags = flags;
 	other_view->custom.diff_cmp_flags = flags;
 

--- a/src/compare.c
+++ b/src/compare.c
@@ -722,6 +722,9 @@ compare_one_pane(view_t *view, CompareType ct, ListType lt, int flags)
 		rn_leave(other, 1);
 	}
 
+	curr_view->custom.diff_cmp_flags = flags;
+	other_view->custom.diff_cmp_flags = flags;
+
 	view->list_pos = 0;
 	ui_view_schedule_redraw(view);
 	return 0;

--- a/src/compare.h
+++ b/src/compare.h
@@ -21,15 +21,6 @@
 
 #include "ui/ui.h"
 
-/* Type of files to list after a comparison. */
-typedef enum
-{
-	LT_ALL,    /* All files. */
-	LT_DUPS,   /* Files that have at least 1 dup on other side or in this view. */
-	LT_UNIQUE, /* Files unique to this view or within this view. */
-}
-ListType;
-
 /* Comparison flags. */
 typedef enum
 {

--- a/src/compare.h
+++ b/src/compare.h
@@ -46,6 +46,8 @@ typedef enum
 	CF_SHOW_UNIQUE_LEFT  = 64,  /* Show unique left files in comparison. */
 	CF_SHOW_UNIQUE_RIGHT = 128, /* Show unique right files in comparison. */
 
+	CF_SINGLE_PANE       = 256, /* Single pane mode */
+
 	/* Mask of show* flags. */
 	CF_SHOW = CF_SHOW_IDENTICAL
 	        | CF_SHOW_DIFFERENT

--- a/src/compare.h
+++ b/src/compare.h
@@ -33,13 +33,24 @@ ListType;
 /* Comparison flags. */
 typedef enum
 {
-	CF_NONE         = 0, /* No flags. */
-	CF_GROUP_PATHS  = 1, /* Otherwise ids are grouped.  Only for two-pane
-                        * compare. */
-	CF_SKIP_EMPTY   = 2, /* Exclude empty files from comparison. */
-	CF_IGNORE_CASE  = 4, /* Compare file names case-insensitively. */
-	CF_RESPECT_CASE = 8, /* Compare file names case-sensitively.  Case is
-	                        OS/FS-specific if neither CF_*_CASE flag is set. */
+	CF_NONE              = 0, /* No flags. */
+	CF_GROUP_PATHS       = 1, /* Otherwise ids are grouped.  Only for two-pane
+                             * compare. */
+	CF_SKIP_EMPTY        = 2, /* Exclude empty files from comparison. */
+	CF_IGNORE_CASE       = 4, /* Compare file names case-insensitively. */
+	CF_RESPECT_CASE      = 8, /* Compare file names case-sensitively.  Case is
+	                             OS/FS-specific if neither CF_*_CASE flag is set. */
+
+	CF_SHOW_IDENTICAL    = 16,  /* Show identical files in comparison. */
+	CF_SHOW_DIFFERENT    = 32,  /* Show different files in comparison. */
+	CF_SHOW_UNIQUE_LEFT  = 64,  /* Show unique left files in comparison. */
+	CF_SHOW_UNIQUE_RIGHT = 128, /* Show unique right files in comparison. */
+
+	/* Mask of show* flags. */
+	CF_SHOW = CF_SHOW_IDENTICAL
+	        | CF_SHOW_DIFFERENT
+	        | CF_SHOW_UNIQUE_LEFT
+	        | CF_SHOW_UNIQUE_RIGHT,
 }
 CompareFlags;
 

--- a/src/modes/modes.c
+++ b/src/modes/modes.c
@@ -397,20 +397,31 @@ abort_menu_like_mode(void)
 static void
 print_compare_stats(void)
 {
-	if(curr_view->custom.diff_cmp_flags & CF_GROUP_PATHS)
+	int flags = curr_view->custom.diff_cmp_flags;
+	const compare_stats_t *stats = &curr_view->custom.diff_stats;
+
+	if(flags & CF_GROUP_PATHS)
 	{
-		ui_sb_msgf("(on compare) identical: %d, different: %d, unique: %d/%d",
-				curr_view->custom.diff_stats.identical,
-				curr_view->custom.diff_stats.different,
-				curr_view->custom.diff_stats.unique_left,
-				curr_view->custom.diff_stats.unique_right);
+		ui_sb_msgf("(on compare) "
+				"%cidentical: %d, %cdifferent: %d, %c/%cunique: %d/%d",
+				flags & CF_SHOW_IDENTICAL ? '+' : '-',
+				stats->identical,
+				flags & CF_SHOW_DIFFERENT ? '+' : '-',
+				stats->different,
+				flags & CF_SHOW_UNIQUE_LEFT ? '+' : '-',
+				flags & CF_SHOW_UNIQUE_RIGHT ? '+' : '-',
+				stats->unique_left,
+				stats->unique_right);
 	}
 	else
 	{
-		ui_sb_msgf("(on compare) identical: %d, unique: %d/%d",
-				curr_view->custom.diff_stats.identical,
-				curr_view->custom.diff_stats.unique_left,
-				curr_view->custom.diff_stats.unique_right);
+		ui_sb_msgf("(on compare) %cidentical: %d, %c/%cunique: %d/%d",
+				flags & CF_SHOW_IDENTICAL ? '+' : '-',
+				stats->identical,
+				flags & CF_SHOW_UNIQUE_LEFT ? '+' : '-',
+				flags & CF_SHOW_UNIQUE_RIGHT ? '+' : '-',
+				stats->unique_left,
+				stats->unique_right);
 	}
 	curr_stats.save_msg = 2;
 }

--- a/src/modes/modes.c
+++ b/src/modes/modes.c
@@ -400,6 +400,11 @@ print_compare_stats(void)
 	int flags = curr_view->custom.diff_cmp_flags;
 	const compare_stats_t *stats = &curr_view->custom.diff_stats;
 
+	if(flags & CF_SINGLE_PANE)
+	{
+		return;
+	}
+
 	if(flags & CF_GROUP_PATHS)
 	{
 		ui_sb_msgf("(on compare) "
@@ -423,6 +428,7 @@ print_compare_stats(void)
 				stats->unique_left,
 				stats->unique_right);
 	}
+
 	curr_stats.save_msg = 2;
 }
 

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -61,6 +61,7 @@
 #include "../utils/string_array.h"
 #include "../utils/utf8.h"
 #include "../utils/utils.h"
+#include "../compare.h"
 #include "../event_loop.h"
 #include "../filelist.h"
 #include "../flist_sel.h"
@@ -1641,6 +1642,14 @@ ui_swap_view_data(view_t *left, view_t *right)
 	t = right->custom.diff_stats.unique_left;
 	right->custom.diff_stats.unique_left = right->custom.diff_stats.unique_right;
 	right->custom.diff_stats.unique_right = t;
+
+	const int unique_lr = (CF_SHOW_UNIQUE_LEFT | CF_SHOW_UNIQUE_RIGHT);
+	if((left->custom.diff_cmp_flags & unique_lr) == CF_SHOW_UNIQUE_LEFT ||
+			(left->custom.diff_cmp_flags & unique_lr) == CF_SHOW_UNIQUE_RIGHT)
+	{
+		left->custom.diff_cmp_flags ^= unique_lr;
+		right->custom.diff_cmp_flags ^= unique_lr;
+	}
 
 	tmp_view = *left;
 	*left = *right;

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -165,6 +165,15 @@ typedef enum
 }
 CompareType;
 
+/* Type of files to list after a comparison. */
+typedef enum
+{
+	LT_ALL,    /* All files. */
+	LT_DUPS,   /* Files that have at least 1 dup on other side or in this view. */
+	LT_UNIQUE, /* Files unique to this view or within this view. */
+}
+ListType;
+
 /* Type of scheduled view update event. */
 typedef enum
 {
@@ -272,6 +281,7 @@ struct cv_data_t
 
 	/* Additional data for CV_DIFF type. */
 	CompareType diff_cmp_type;  /* Type of comparison. */
+	ListType diff_list_type;    /* Type of results. */
 	int diff_cmp_flags;         /* Flags used to build the diff. */
 	compare_stats_t diff_stats; /* List of comparison results */
 

--- a/tests/commands/misc.c
+++ b/tests/commands/misc.c
@@ -356,7 +356,8 @@ TEST(compare)
 	assert_true(flist_custom_active(&lwin));
 	assert_true(flist_custom_active(&rwin));
 	assert_int_equal(CT_NAME, lwin.custom.diff_cmp_type);
-	assert_int_equal(CF_GROUP_PATHS | CF_IGNORE_CASE, lwin.custom.diff_cmp_flags);
+	assert_int_equal(CF_GROUP_PATHS | CF_IGNORE_CASE | CF_SHOW,
+			lwin.custom.diff_cmp_flags);
 	assert_success(chdir(cwd));
 
 	assert_success(remove(SANDBOX_PATH "/file"));

--- a/tests/commands/tabs.c
+++ b/tests/commands/tabs.c
@@ -130,7 +130,7 @@ TEST(newtab_fails_in_diff_mode_for_tab_panes)
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
 
 	cfg.pane_tabs = 1;
-	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 	assert_failure(exec_commands("tabnew", &lwin, CIT_COMMAND));
 	assert_int_equal(1, tabs_count(&lwin));
 }

--- a/tests/misc/compare.c
+++ b/tests/misc/compare.c
@@ -84,7 +84,7 @@ TEST(two_panes_by_name_ignore_case)
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/rename");
 
-	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS | CF_IGNORE_CASE);
+	compare_two_panes(CT_NAME, LT_ALL, CF_SHOW | CF_GROUP_PATHS | CF_IGNORE_CASE);
 
 	check_compare_invariants(3);
 
@@ -113,7 +113,8 @@ TEST(two_panes_by_name_respect_case)
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/rename");
 
-	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS | CF_RESPECT_CASE);
+	compare_two_panes(CT_NAME, LT_ALL,
+			CF_SHOW | CF_GROUP_PATHS | CF_RESPECT_CASE);
 
 	check_compare_invariants(6);
 
@@ -126,7 +127,7 @@ TEST(two_panes_all_group_ids)
 {
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_NAME, LT_ALL, CF_NONE);
+	compare_two_panes(CT_NAME, LT_ALL, CF_SHOW);
 
 	check_compare_invariants(4);
 
@@ -151,7 +152,7 @@ TEST(two_panes_all_group_paths)
 	other_view = &lwin;
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	check_compare_invariants(4);
 
@@ -176,7 +177,7 @@ TEST(two_panes_dups_one_is_empty)
 	other_view = &lwin;
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	check_compare_invariants(4);
 
@@ -199,7 +200,7 @@ TEST(two_panes_dups)
 {
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_CONTENTS, LT_DUPS, CF_GROUP_PATHS);
+	compare_two_panes(CT_CONTENTS, LT_DUPS, CF_GROUP_PATHS | CF_SHOW);
 
 	check_compare_invariants(3);
 
@@ -219,7 +220,7 @@ TEST(two_panes_unique)
 {
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_CONTENTS, LT_UNIQUE, CF_GROUP_PATHS);
+	compare_two_panes(CT_CONTENTS, LT_UNIQUE, CF_GROUP_PATHS | CF_SHOW);
 
 	assert_int_equal(1, lwin.list_rows);
 	assert_int_equal(1, rwin.list_rows);
@@ -298,7 +299,7 @@ TEST(relatively_complex_match)
 	other_view = &lwin;
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/read");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	check_compare_invariants(10);
 
@@ -366,7 +367,7 @@ TEST(content_difference_is_detected)
 	other_view = &rwin;
 	strcpy(lwin.curr_dir, SANDBOX_PATH "/a");
 	strcpy(rwin.curr_dir, SANDBOX_PATH "/b");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	assert_int_equal(1, lwin.list_rows);
 	assert_int_equal(1, rwin.list_rows);

--- a/tests/misc/compare_misc.c
+++ b/tests/misc/compare_misc.c
@@ -68,7 +68,7 @@ TEST(empty_root_directories_abort_dual_comparison)
 	strcpy(lwin.curr_dir, SANDBOX_PATH "/a");
 	strcpy(rwin.curr_dir, SANDBOX_PATH "/b");
 
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 	assert_false(flist_custom_active(&lwin));
 
 	assert_success(rmdir(SANDBOX_PATH "/a"));
@@ -83,7 +83,7 @@ TEST(empty_unique_cv_are_created)
 	strcpy(lwin.curr_dir, SANDBOX_PATH "/a");
 	strcpy(rwin.curr_dir, SANDBOX_PATH "/b");
 
-	compare_two_panes(CT_CONTENTS, LT_UNIQUE, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_UNIQUE, CF_SHOW);
 	assert_true(flist_custom_active(&lwin));
 	assert_true(flist_custom_active(&rwin));
 
@@ -147,7 +147,7 @@ TEST(two_panes_are_left_in_sync)
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/a");
 
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 	assert_true(flist_custom_active(&lwin));
 	assert_true(flist_custom_active(&rwin));
 
@@ -169,7 +169,7 @@ TEST(exclude_works_with_entries_or_their_groups)
 
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/a");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 	check_compare_invariants(5);
 
 	/* Does nothing on separator. */
@@ -220,7 +220,7 @@ TEST(local_filter_is_not_set)
 {
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_NAME, LT_ALL, CF_NONE);
+	compare_two_panes(CT_NAME, LT_ALL, CF_SHOW);
 
 	exec_command("f", &lwin, CIT_FILTER_PATTERN);
 	assert_true(filter_is_empty(&lwin.local_filter.filter));
@@ -242,7 +242,7 @@ TEST(removed_files_disappear_in_both_views_on_reload)
 
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/a");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 	check_compare_invariants(5);
 
 	assert_success(remove(SANDBOX_PATH "/same-content-different-name-1"));
@@ -271,7 +271,7 @@ TEST(comparison_views_are_closed_when_no_files_are_left)
 
 	strcpy(lwin.curr_dir, SANDBOX_PATH "/a");
 	strcpy(rwin.curr_dir, SANDBOX_PATH "/b");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 	check_compare_invariants(1);
 
 	assert_success(remove(SANDBOX_PATH "/a/same-content-different-name-1"));
@@ -309,7 +309,7 @@ TEST(cursor_moves_in_both_views_synchronously)
 {
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_NAME, LT_ALL, CF_NONE);
+	compare_two_panes(CT_NAME, LT_ALL, CF_SHOW);
 
 	assert_int_equal(0, lwin.list_pos);
 	assert_int_equal(lwin.list_pos, rwin.list_pos);
@@ -346,7 +346,7 @@ TEST(diff_is_closed_by_single_compare)
 {
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_NAME, LT_ALL, CF_NONE);
+	compare_two_panes(CT_NAME, LT_ALL, CF_SHOW);
 
 	assert_int_equal(CV_DIFF, lwin.custom.type);
 	assert_int_equal(CV_DIFF, rwin.custom.type);
@@ -362,7 +362,7 @@ TEST(filtering_fake_entry_does_nothing)
 	other_view = &lwin;
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	assert_int_equal(4, lwin.list_rows);
 	assert_int_equal(4, rwin.list_rows);
@@ -384,7 +384,7 @@ TEST(filtering_updates_two_bound_views)
 	other_view = &lwin;
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 
 	/* Check that single file is excluded. */
 
@@ -430,7 +430,7 @@ TEST(two_pane_dups_renumbering)
 	other_view = &lwin;
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/read");
-	compare_two_panes(CT_CONTENTS, LT_DUPS, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_DUPS, CF_SHOW);
 
 	check_compare_invariants(2);
 
@@ -449,7 +449,7 @@ TEST(removing_all_files_of_same_id_and_fake_entry_on_the_other_side)
 
 	strcpy(lwin.curr_dir, SANDBOX_PATH);
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/read");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 
 	check_compare_invariants(7);
 
@@ -474,7 +474,7 @@ TEST(compare_considers_dot_filter)
 	rwin.hide_dot = 1;
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/tree");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/tree/dir5");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 	assert_int_equal(6, lwin.list_rows);
 	assert_int_equal(6, rwin.list_rows);
 }
@@ -495,7 +495,7 @@ TEST(compare_considers_name_filters)
 	load_dir_list(&rwin, 1);
 	assert_int_equal(1, rwin.list_rows);
 
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 
 	check_compare_invariants(3);
 
@@ -512,7 +512,7 @@ TEST(empty_files_are_skipped_if_requested)
 {
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SKIP_EMPTY);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SKIP_EMPTY | CF_SHOW);
 	check_compare_invariants(4);
 }
 
@@ -536,7 +536,7 @@ TEST(custom_views_are_compared)
 
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
 
-	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	check_compare_invariants(4);
 
@@ -565,7 +565,7 @@ TEST(directories_are_not_added_from_custom_views)
 
 	strcpy(rwin.curr_dir, SANDBOX_PATH);
 
-	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS);
+	compare_two_panes(CT_NAME, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	check_compare_invariants(1);
 
@@ -578,7 +578,7 @@ TEST(the_same_directories_are_not_compared)
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare");
 
-	compare_two_panes(CT_CONTENTS, LT_ALL, CF_NONE);
+	compare_two_panes(CT_CONTENTS, LT_ALL, CF_SHOW);
 	assert_false(flist_custom_active(&lwin));
 	assert_false(flist_custom_active(&rwin));
 }
@@ -599,7 +599,7 @@ TEST(two_panes_unique_is_symmetric)
 
 	curr_view = &lwin;
 	other_view = &rwin;
-	compare_two_panes(CT_NAME, LT_UNIQUE, CF_NONE);
+	compare_two_panes(CT_NAME, LT_UNIQUE, CF_SHOW);
 	assert_int_equal(1, lwin.list_rows);
 	assert_int_equal(1, rwin.list_rows);
 	assert_string_equal("fileb", lwin.dir_entry[0].name);
@@ -610,7 +610,7 @@ TEST(two_panes_unique_is_symmetric)
 
 	curr_view = &rwin;
 	other_view = &lwin;
-	compare_two_panes(CT_NAME, LT_UNIQUE, CF_NONE);
+	compare_two_panes(CT_NAME, LT_UNIQUE, CF_SHOW);
 	assert_int_equal(1, lwin.list_rows);
 	assert_int_equal(1, rwin.list_rows);
 	assert_string_equal("fileb", lwin.dir_entry[0].name);

--- a/tests/misc/diff.c
+++ b/tests/misc/diff.c
@@ -10,12 +10,17 @@
 #include <test-utils.h>
 
 #include "../../src/cfg/config.h"
+#include "../../src/engine/keys.h"
+#include "../../src/modes/modes.h"
+#include "../../src/modes/wk.h"
 #include "../../src/ui/column_view.h"
+#include "../../src/ui/statusbar.h"
 #include "../../src/ui/ui.h"
 #include "../../src/utils/fs.h"
 #include "../../src/compare.h"
 #include "../../src/event_loop.h"
 #include "../../src/ops.h"
+#include "../../src/status.h"
 
 static void column_line_print(const char buf[], size_t offset, AlignType align,
 		const char full_column[], const format_info_t *info);
@@ -31,6 +36,7 @@ SETUP()
 	view_setup(&lwin);
 	view_setup(&rwin);
 
+	init_modes();
 	opt_handlers_setup();
 
 	cfg.use_system_calls = 1;
@@ -48,6 +54,7 @@ TEARDOWN()
 	view_teardown(&lwin);
 	view_teardown(&rwin);
 
+	vle_keys_reset();
 	opt_handlers_teardown();
 
 	undo_teardown();
@@ -178,6 +185,40 @@ TEST(moving_equal_does_nothing)
 				TEST_DATA_PATH "/compare/b/same-name-same-content"));
 
 	assert_success(remove(SANDBOX_PATH "/same-name-same-content"));
+}
+
+TEST(diff_stats_are_correct_and_stays_correct)
+{
+	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
+	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
+
+	ui_sb_msg("");
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL,
+			CF_SHOW_UNIQUE_LEFT | CF_SHOW_IDENTICAL);
+	modes_statusbar_update();
+	assert_string_equal("(on compare) +identical: 2, +/-unique: 1/2",
+			ui_sb_last());
+	(void)vle_keys_exec_timed_out(WK_C_w WK_x);
+	curr_stats.save_msg = 0;
+	modes_statusbar_update();
+	assert_string_equal("(on compare) +identical: 2, -/+unique: 2/1",
+			ui_sb_last());
+
+	/* Repeat the same, but with grouping by paths. */
+	ui_sb_msg("");
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL,
+			CF_SHOW_UNIQUE_LEFT | CF_SHOW_IDENTICAL | CF_GROUP_PATHS);
+	curr_stats.save_msg = 0;
+	modes_statusbar_update();
+	assert_string_equal(
+			"(on compare) +identical: 2, -different: 1, +/-unique: 1/0",
+			ui_sb_last());
+	(void)vle_keys_exec_timed_out(WK_C_w WK_x);
+	curr_stats.save_msg = 0;
+	modes_statusbar_update();
+	assert_string_equal(
+			"(on compare) +identical: 2, -different: 1, -/+unique: 0/1",
+			ui_sb_last());
 }
 
 TEST(file_id_is_not_updated_on_failed_move, IF(regular_unix_user))

--- a/tests/misc/diff.c
+++ b/tests/misc/diff.c
@@ -73,7 +73,7 @@ TEST(moving_fake_entry_removes_the_other_file)
 
 	create_file(SANDBOX_PATH "/empty");
 
-	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 	rwin.list_pos = 0;
 	lwin.list_pos = 0;
 	(void)compare_move(&lwin, &rwin);
@@ -88,7 +88,7 @@ TEST(moving_to_fake_entry_creates_the_other_file_and_entry_is_updated)
 	make_abs_path(lwin.curr_dir, sizeof(lwin.curr_dir), TEST_DATA_PATH,
 			"compare/b", saved_cwd);
 
-	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 	rwin.list_pos = 3;
 	lwin.list_pos = 3;
 	(void)compare_move(&lwin, &rwin);
@@ -139,7 +139,7 @@ TEST(moving_mismatched_entry_makes_files_equal)
 	assert_false(files_are_identical(SANDBOX_PATH "/same-name-different-content",
 				TEST_DATA_PATH "/compare/b/same-name-different-content"));
 
-	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 	rwin.list_pos = 2;
 	lwin.list_pos = 2;
 	(void)compare_move(&lwin, &rwin);
@@ -161,7 +161,7 @@ TEST(moving_equal_does_nothing)
 	assert_true(files_are_identical(SANDBOX_PATH "/same-name-same-content",
 				TEST_DATA_PATH "/compare/b/same-name-same-content"));
 
-	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	/* Replace file unbeknownst to main code. */
 	copy_file(TEST_DATA_PATH "/compare/a/same-name-different-content",
@@ -193,7 +193,7 @@ TEST(file_id_is_not_updated_on_failed_move, IF(regular_unix_user))
 	assert_false(files_are_identical(SANDBOX_PATH "/same-name-different-content",
 				TEST_DATA_PATH "/compare/b/same-name-different-content"));
 
-	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 	rwin.list_pos = 2;
 	lwin.list_pos = 2;
 

--- a/tests/misc/flist_misc.c
+++ b/tests/misc/flist_misc.c
@@ -208,7 +208,7 @@ TEST(find_next_and_prev_mismatches)
 
 	strcpy(lwin.curr_dir, TEST_DATA_PATH "/compare/a");
 	strcpy(rwin.curr_dir, TEST_DATA_PATH "/compare/b");
-	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS);
+	(void)compare_two_panes(CT_CONTENTS, LT_ALL, CF_GROUP_PATHS | CF_SHOW);
 
 	assert_int_equal(4, lwin.list_rows);
 	assert_int_equal(4, rwin.list_rows);


### PR DESCRIPTION
Added toggled `showidentical | showdifferent | showuniqueleft | showuniqueright` arguments for :compare command. If current view is `cv_compare` then arguments will be toggled with existed before comparing.

Now applying of them is restarting comparing. I don't know which is better. May be result of `flist_custom_put` calls can be saved to self-erased (on exit from compare view) structure, but I doubt.

Also disabled printing stats for `ofone` mode by moving `single_pane` to `CompareFlags`