### PR TITLE
Fix incorrect plugin loading path

### DIFF
--- a/src/lua/vlua.h
+++ b/src/lua/vlua.h
@@ -37,7 +37,7 @@ struct view_t;
 vlua_t * vlua_init(void);
 
 /* Loads a single plugin on request.  Returns zero on success. */
-int vlua_load_plugin(vlua_t *vlua, const char plugin[], struct plug_t *plug);
+int vlua_load_plugin(vlua_t *vlua, struct plug_t *plug);
 
 /* Frees resources of the unit.  The parameter can be NULL. */
 void vlua_finish(vlua_t *vlua);

--- a/src/plugins.c
+++ b/src/plugins.c
@@ -197,7 +197,7 @@ load_plugs_dir(plugs_t *plugs, const char plugin_path[])
 			plug_log(plug, "[vifm][info]: skipped due to blacklist/whitelist");
 			plug->status = PLS_SKIPPED;
 		}
-		else if(vlua_load_plugin(plugs->vlua, entry->d_name, plug) == 0)
+		else if(vlua_load_plugin(plugs->vlua, plug) == 0)
 		{
 			plug_log(plug, "[vifm][info]: plugin was loaded successfully");
 			plug->status = PLS_SUCCESS;


### PR DESCRIPTION
Hi, with the latest `--plugins-dir` option, I found vifm will always load plugin under `cfg.config_dir` (in my case, it is `$HOME/.config/vifm/plugins`), but it should respect the `plug->real_path`.
So I made this quick fix without looking too deep into the source.

todo:
* is the name param still necessary? since we get full_path from `plug->real_path` now
* add a test