### PR TITLE
Fix potential null dereference

### DIFF
--- a/src/utils/trie.c
+++ b/src/utils/trie.c
@@ -97,6 +97,10 @@ trie_t *
 trie_create(trie_free_func free_func)
 {
 	trie_t *trie = calloc(1U, sizeof(*trie));
+	if(trie == NULL)
+	{
+		return NULL;
+	}
 	trie->free_func = free_func;
 	return trie;
 }
@@ -318,6 +322,10 @@ make_node(trie_t *trie)
 
 		trie->nodes = nodes;
 		trie->nodes[bank] = calloc(NODES_PER_BANK, sizeof(**trie->nodes));
+		if(trie->nodes[bank] == NULL)
+		{
+			return NULL;
+		}
 	}
 
 	return &trie->nodes[bank][bank_index];


### PR DESCRIPTION
**Description**
Fix the null dereference warning detected by static analyse tool infer@facebook

**Warning Type**
Null Dereference

**Component Name**
vifm/src/utils/trie.c(line: 99)
vifm/src/utils/trie.c(line: 320)

**Additional Information**
pointer `trie` last assigned on line 99 could be null and is dereferenced at line 100.
pointer `trie->nodes[bank]` last assigned on line 320 could be null and is dereferenced at line 323.