### PR TITLE
Fix xclip keybinds

### DIFF
--- a/data/vifmrc
+++ b/data/vifmrc
@@ -479,9 +479,9 @@ elseif $WAYLAND_DISPLAY
 elseif $DISPLAY
     if executable('xclip')
         " Yank current directory path into the clipboard
-        nnoremap yd :!echo %d | xclip %i<cr>
+        nnoremap yd :!echo -n %d | xclip -selection clipboard %i<cr>
         " Yank current file path into the clipboard
-        nnoremap yf :!echo %c:p | xclip %i<cr>
+        nnoremap yf :!echo -n %c:p | xclip -selection clipboard %i<cr>
     elseif executable('xsel')
         " Yank current directory path into primary and selection clipboards
         nnoremap yd :!echo -n %d | xsel --input --primary %i &&


### PR DESCRIPTION
I copied xclip keybinds from [this](https://wiki.vifm.info/index.php/How_to_copy_path_to_current_file/directory_to_system_clipboard) article to my config and realised that two keybinds (path yank ones) are already there but not working. 

Added `-n` argument to `echo` and `-selection clipboard` to `xclip`.