### PR TITLE
Add helix handler to editor plugin

### DIFF
--- a/data/plugins/editor/helix.lua
+++ b/data/plugins/editor/helix.lua
@@ -1,0 +1,61 @@
+--[[
+
+Wraps helix for handling basic editor use cases within Vifm.
+
+Unimplemented actions:
+ * open-help (:help when 'vimhelp' is set):
+ * edit-list ("v" key in navigation menus):
+   See: https://github.com/helix-editor/helix/discussions/5902
+
+--]]
+
+local M = {}
+
+M.handlers = {}
+
+M.handlers["open-help"] = function(info)
+    vifm.errordialog("Unimplemented",
+                     "Can't view Vim-style help via Helix.\n"..
+                     "Do `:set novimhelp` to make argumentless `:help` work.")
+    return false
+end
+
+M.handlers["edit-one"] = function(info)
+    local posarg = ""
+    if info.line ~= nil and info.column == nil then
+        posarg = ':' .. info.line
+    elseif info.line ~= nil and info.column ~= nil then
+        posarg = string.format(":%d:%d", info.line, info.column)
+    end
+
+    local exitcode = vifm.run {
+        cmd = string.format("hx %s%s", vifm.escape(info.path), posarg),
+        usetermmux = not info.mustwait,
+    }
+
+    return exitcode == 0
+end
+
+function map(table, functor)
+    local result = {}
+    for key, value in pairs(table) do
+        result[key] = functor(value)
+    end
+    return result
+end
+
+M.handlers["edit-many"] = function(info)
+    local exitcode = vifm.run {
+        cmd = string.format("hx %s",
+                            table.concat(map(info.paths, vifm.escape), ' '))
+    }
+
+    return exitcode == 0
+end
+
+M.handlers["edit-list"] = function(info)
+    vifm.errordialog("Unimplemented", "Can't view quickfix via Helix.")
+    return false
+end
+
+return M

--- a/data/plugins/editor/init.lua
+++ b/data/plugins/editor/init.lua
@@ -7,6 +7,7 @@ Builtin wrappers:
  * emacs
  * gvim
  * vim
+ * helix
 
 Usage example:
 
@@ -20,6 +21,7 @@ local impls = {
     emacs = vifm.plugin.require('emacs'),
     gvim = vifm.plugin.require('gvim'),
     vim = vifm.plugin.require('vim'),
+    helix = vifm.plugin.require('helix'),
 }
 
 local function run(info)


### PR DESCRIPTION
Allows using [Helix](https://github.com/helix-editor/helix/) as the default editor, `open-help` and `edit-list` handlers are not implemented.

Closes: https://github.com/vifm/vifm/issues/925
See also: https://github.com/helix-editor/helix/discussions/5902