### PR TITLE
Handle other types of files in ueberzug plugin

### DIFF
--- a/data/plugins/ueberzug/init.lua
+++ b/data/plugins/ueberzug/init.lua
@@ -5,38 +5,84 @@ Enables use of Ueberzug for viewing images:
  - prints an error message to preview area if command isn't found
  - restarts Ueberzug if it exits (you also get an error message about it)
 
-Usage example:
-
-    :fileviewer {*.png}
-              \ #ueberzug#view %px %py %pw %ph
-              \ %pc
-              \ #ueberzug#clear
-
 Ueberzug:
  - original (discontinued): https://github.com/seebye/ueberzug/
  - fork of python version:  https://github.com/ueber-devel/ueberzug
  - improved rewrite in C++: https://github.com/jstkdng/ueberzugpp
+
+Usage example:
+    fileviewer <image/*>
+        \ #ueberzug#image_no_cache %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+    fileviewer <video/*>
+        \ #ueberzug#video %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+    fileviewer <audio/*>
+        \ #ueberzug#audio %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+    fileviewer <font/*>
+        \ #ueberzug#djvu %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+
+    fileviewer *.pdf
+        \ #ueberzug#pdf %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+    fileviewer *.epub
+        \ #ueberzug#epub %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+    fileviewer *.djvu
+        \ #ueberzug#djvu %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+
+    fileviewer *.cbz
+        \ #ueberzug#cbz %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+    fileviewer *.cbt
+        \ vifmimg cbt %px %py %pw %ph %c
+        \ %pc
+        \ vifmimg clear
+    fileviewer *.cbr
+        \ vifmimg cbr %px %py %pw %ph %c
+        \ %pc
+        \ vifmimg clear
+    fileviewer *.cb7
+        \ vifmimg cb7 %px %py %pw %ph %c
+        \ %pc
+        \ vifmimg clear
 
 --]]
 
 -- TODO: maybe don't register handlers if executable isn't present to allow
 --       other viewers to kick in
 -- TODO: generate JSON properly
--- TODO: handle other types of files
 -- TODO: stop Ueberzug after some period of inactivity (needs timer API?)
 
-local M = { }
-local layer_id = "vifm-preview"
-
+local M = {}
+local layer_id = 'vifm-preview'
 local pipe_storage
+local cache_path_storage
+
 local function get_pipe()
     if pipe_storage == nil then
-        if not vifm.executable('ueberzug') then
+        local cmd
+        if vifm.executable('ueberzugpp') then
+            cmd = 'ueberzugpp layer --no-cache'
+        elseif vifm.executable('ueberzug') then
+            cmd = 'ueberzug layer'
+        else
             return nil, "ueberzug executable isn't found"
         end
 
         local uberzug = vifm.startjob {
-            cmd = 'ueberzug layer',
+            cmd = cmd,
             iomode = 'w',
             onexit = function()
                 pipe_storage = nil
@@ -50,24 +96,16 @@ local function get_pipe()
     return pipe_storage
 end
 
-local function view(info)
-    local pipe, err = get_pipe()
-    if pipe == nil then
-        return { lines = { err } }
+local function get_cache_path()
+    if cache_path_sorage == nil then
+        local cache_path = os.getenv('XDG_CACHE_HOME')
+        if not cache_path then
+          cache_path = os.getenv('HOME')..'/.cache'
+        end
+        cache_path_storage = cache_path..'/ueberzug/'
+        vifm.makepath(cache_path_storage)
     end
-
-    local format = '{ "action":"add", "identifier":"%s",'
-                 ..'  "x":%d, "y":%d, "width":%d, "height":%d,'
-                 ..'  "path":"%s"'
-                 ..'}\n'
-
-    local message = format:format(layer_id,
-                                  info.x, info.y, info.width, info.height,
-                                  info.path)
-    print(message)
-    pipe:write(message)
-    pipe:flush()
-    return { lines = {} }
+    return cache_path_storage
 end
 
 local function clear(info)
@@ -77,7 +115,6 @@ local function clear(info)
     end
 
     local format = '{"action":"remove", "identifier":"%s"}\n'
-
     local message = format:format(layer_id)
     print(message)
     pipe:write(message)
@@ -85,20 +122,151 @@ local function clear(info)
     return { lines = {} }
 end
 
-local added = vifm.addhandler {
-    name = "view",
-    handler = view,
-}
-if not added then
-    vifm.sb.error("Failed to register #view")
+local function view(info)
+    local pipe, err = get_pipe()
+    if pipe == nil then
+        return { lines = { err } }
+    end
+
+    local format = '{"action":"add", "identifier":"%s",'
+                 ..' "x":%d, "y":%d, "width":%d, "height":%d,'
+                 ..' "path":"%s"}\n'
+    local message = format:format(layer_id,
+                                  info.x, info.y, info.width, info.height,
+                                  info.path)
+    print(message)
+    pipe:write(message)
+    pipe:flush()
+    return { lines = {} }
 end
 
-local added = vifm.addhandler {
-    name = "clear",
-    handler = clear,
-}
-if not added then
-    vifm.sb.error("Failed to register #clear")
+local function cached_view_with(info, ext, thumbnailer)
+    local function get_thumb_path_without_extension(path)
+        local cache_path = get_cache_path()
+        local job = vifm.startjob {
+            cmd = 'stat --printf "%n%i%F%s%W%Y" -- "'..path..'" | sha512sum',
+        }
+        local sha = job:stdout():read('*all'):sub(1, -5)
+        return cache_path..sha
+    end
+
+    local function file_exists(path)
+       local f = io.open(path, "r")
+       return f ~= nil and io.close(f)
+    end
+
+    local thumb_partial_path = get_thumb_path_without_extension(info.path)
+    local thumb_full_path = thumb_partial_path..ext
+    if not file_exists(thumb_full_path) then
+        thumbnailer(thumb_full_path, thumb_partial_path, ext)
+    end
+    info.path = thumb_full_path
+    return view(info)
 end
+
+local function cached_view(info, fmt)
+    local thumbnailer = function(thumb_full_path)
+        vifm.startjob { cmd = fmt:format(info.path, thumb_full_path) }:wait()
+    end
+    cached_view_with(info, '.jpg', thumbnailer)
+end
+
+local function cached_view_for_archives(info, mount_fmt)
+    local thumbnailer = function(thumb_full_path)
+        local mount_cmd = mount_fmt:format(info.path)
+        local cmd = ([[
+            tmpdir="$(mktemp --directory)"
+            cleanup() { 
+                tmpdir="$1"
+                mountpoint -q -- "$tmpdir"
+                is_mounted=$?
+                [ "$is_mounted" = 0 ] && fusermount -u "$tmpdir"
+                rm -rf "$tmpdir"
+            }
+            trap "cleanup $tmpdir" EXIT
+
+            %s
+            first_image="$(find "$tmpdir" -type f \( -iname "*.png" -o -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.webp" \) | sort | head -1)"
+            convert -thumbnail 720 "$first_image" "%s"
+        ]]):format(mount_cmd, thumb_full_path)
+        vifm.startjob { cmd = cmd }:wait()
+    end
+
+    cached_view_with(info, '.jpg', thumbnailer)
+end
+
+local function image_no_cache(info)
+    return view(info)
+end
+local function image(info)
+    return cached_view(info, 'convert -thumbnail 720 "%s" "%s"')
+end
+local function video(info)
+    return cached_view(info, 'ffmpegthumbnailer -i "%s" -o "%s" -s 0 -q 5')
+end
+local function audio(info)
+    return cached_view(info, 'ffmpeg -hide_banner -i "%s" "%s" -y >/dev/null')
+end
+local function font(info)
+    return cached_view(info, 'fontpreview -i "%s" -o "%s"')
+end
+
+local function epub(info)
+    return cached_view(info, 'gnome-epub-thumbnailer "%s" "%s" -s 720')
+end
+local function djvu(info)
+    return cached_view(info, 'ddjvu -format=tiff -quality=90 -page=1 "%s" "%s"')
+end
+local function pdf(info)
+    local thumbnailer = function(_, thumb_partial_path)
+        local fmt = 'pdftoppm -jpeg -f 1 -singlefile "%s" "%s"'
+        local cmd = fmt:format(info.path, thumb_partial_path)
+        vifm.startjob { cmd = cmd }:wait()
+    end
+    return cached_view_with(info, ".jpg", thumbnailer)
+end
+
+local function cbz(info)
+    return cached_view_for_archives(info, 'fuse-zip -r "%s" "$tmpdir"')
+end
+local function cbt(info)
+    return cached_view_for_archives(info, 'archivemount "%s" "$tmpdir" -o readonly')
+end
+local function cbr(info)
+    return cached_view_for_archives(info, 'rar2fs "%s" "$tmpdir"')
+end
+local function cb7(info)
+    return cached_view_for_archives(info, 'fuse3-p7zip "%s" "$tmpdir"')
+end
+
+local added = vifm.addhandler { name = 'clear', handler = clear }
+if not added then vifm.sb.error('Failed to register #clear') end
+
+local added = vifm.addhandler { name = 'image', handler = image }
+if not added then vifm.sb.error('Failed to register #image') end
+local added = vifm.addhandler { name = 'image_no_cache', handler = image_no_cache }
+if not added then vifm.sb.error('Failed to register #image_no_cache') end
+local added = vifm.addhandler { name = 'video', handler = video }
+if not added then vifm.sb.error('Failed to register #video') end
+local added = vifm.addhandler { name = 'audio', handler = audio }
+if not added then vifm.sb.error('Failed to register #audio') end
+local added = vifm.addhandler { name = 'font', handler = font }
+if not added then vifm.sb.error('Failed to register #font') end
+
+local added = vifm.addhandler { name = 'pdf', handler = pdf }
+if not added then vifm.sb.error('Failed to register #pdf') end
+local added = vifm.addhandler { name = 'epub', handler = epub }
+if not added then vifm.sb.error('Failed to register #epub') end
+local added = vifm.addhandler { name = 'djvu', handler = djvu }
+if not added then vifm.sb.error('Failed to register #djvu') end
+
+local added = vifm.addhandler { name = 'cbz', handler = cbz }
+if not added then vifm.sb.error('Failed to register #cbz') end
+local added = vifm.addhandler { name = 'cbt', handler = cbt }
+if not added then vifm.sb.error('Failed to register #cbt') end
+local added = vifm.addhandler { name = 'cbr', handler = cbr }
+if not added then vifm.sb.error('Failed to register #cbr') end
+local added = vifm.addhandler { name = 'cb7', handler = cb7 }
+if not added then vifm.sb.error('Failed to register #cb7') end
 
 return M

--- a/data/plugins/ueberzug/init.lua
+++ b/data/plugins/ueberzug/init.lua
@@ -12,7 +12,8 @@ Ueberzug:
 
 Usage example:
     fileviewer <image/*>
-        \ #ueberzug#image_no_cache %px %py %pw %ph
+        \ #ueberzug#image %px %py %pw %ph
+        " or \ #ueberzug#image_no_cache %px %py %pw %ph
         \ %pc
         \ #ueberzug#clear
     fileviewer <video/*>
@@ -102,7 +103,7 @@ local function get_cache_path()
         if not cache_path then
           cache_path = os.getenv('HOME')..'/.cache'
         end
-        cache_path_storage = cache_path..'/ueberzug/'
+        cache_path_storage = cache_path..'/vifm/'
         vifm.makepath(cache_path_storage)
     end
     return cache_path_storage
@@ -202,7 +203,7 @@ local function image(info)
     return cached_view(info, 'convert -thumbnail 720 "%s" "%s"')
 end
 local function video(info)
-    return cached_view(info, 'ffmpegthumbnailer -i "%s" -o "%s" -s 0 -q 5')
+    return cached_view(info, 'ffmpegthumbnailer -i "%s" -o "%s" -s 720 -q 5')
 end
 local function audio(info)
     return cached_view(info, 'ffmpeg -hide_banner -i "%s" "%s" -y >/dev/null')


### PR DESCRIPTION
Adds support for video, audio, font, pdf, epub, djvu and comic book formats with proper caching.

Acknowledgment: Many of the thumbnailer commands are copy pasted from [vifmimg](https://github.com/thimc/vifmimg).

Optional dependencies:
* ImageMagick
* [ffmpegthumbnailer](https://github.com/dirkvdb/ffmpegthumbnailer)
* [fontpreview](https://github.com/sdushantha/fontpreview)
* pdftoppm
* [ddjvu](http://djvu.sourceforge.net/doc/man/ddjvu.html)
* ~[epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer)~ [gnome-epub-thumbnailer](https://gitlab.gnome.org/GNOME/gnome-epub-thumbnailer)
* [fuse-zip](https://bitbucket.org/agalanin/fuse-zip)
* [rar2fs](https://github.com/hasse69/rar2fs)
* [fuse3-p7zip](https://github.com/andrew-grechkin/fuse3-p7zip)
* [archivemount](https://github.com/cybernoid/archivemount)
