### PR TITLE
Fix ueberzug usage example for Gif files

### DIFF
--- a/data/plugins/ueberzug/init.lua
+++ b/data/plugins/ueberzug/init.lua
@@ -11,10 +11,19 @@ Ueberzug:
  - improved rewrite in C++: https://github.com/jstkdng/ueberzugpp
 
 Usage example:
-    fileviewer <video/*>,{*.gif}
+    " If you are using ueberzugpp, you can have animated gif previews with this:
+    fileviewer {*.gif}
+        \ #ueberzug#image_no_cache %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
+
+    " Otherwise, use the video fileviewer for gifs
+    " fileviewer <video/*>,{*.gif}
+    fileviewer <video/*>
         \ #ueberzug#video %px %py %pw %ph
         \ %pc
         \ #ueberzug#clear
+
     fileviewer <image/*>
         \ #ueberzug#image %px %py %pw %ph
         " or \ #ueberzug#image_no_cache %px %py %pw %ph

--- a/data/plugins/ueberzug/init.lua
+++ b/data/plugins/ueberzug/init.lua
@@ -11,13 +11,13 @@ Ueberzug:
  - improved rewrite in C++: https://github.com/jstkdng/ueberzugpp
 
 Usage example:
+    fileviewer <video/*>,{*.gif}
+        \ #ueberzug#video %px %py %pw %ph
+        \ %pc
+        \ #ueberzug#clear
     fileviewer <image/*>
         \ #ueberzug#image %px %py %pw %ph
         " or \ #ueberzug#image_no_cache %px %py %pw %ph
-        \ %pc
-        \ #ueberzug#clear
-    fileviewer <video/*>
-        \ #ueberzug#video %px %py %pw %ph
         \ %pc
         \ #ueberzug#clear
     fileviewer <audio/*>


### PR DESCRIPTION
`#ueberzug#image` can't generate thumbnail for Gif files.

So, I added explanation for two possible choices:
 - Having animated previews by passing the gif file directly to `ueberzugpp` with `#ueberzug#image_no_cache`
 - Or having the usual previews with `ueberzug` which uses the `#ueberzug#video` function instead.