### PR TITLE
Fix get_drive_info on FreeBSD

### DIFF
--- a/src/utils/utils_nix.c
+++ b/src/utils/utils_nix.c
@@ -1245,8 +1245,8 @@ get_drive_info(const char at[], uint64_t *total_bytes, uint64_t *free_bytes)
 		return -1;
 	}
 
-#ifdef __APPLE__
-	/* Apple is so fucking different... */
+#if defined(__APPLE__) || defined(__FreeBSD__)
+	/* Apple and FreeBSD are so fucking different... */
 	const uint64_t block_size = st.f_frsize;
 #else
 	const uint64_t block_size = st.f_bsize;


### PR DESCRIPTION
FreeBSD needs same fix as OS X. See

https://man.freebsd.org/cgi/man.cgi?query=statvfs&sektion=3&n=1