### PR TITLE
Fix Ueberzug gif example

### DIFF
--- a/data/plugins/ueberzug/init.lua
+++ b/data/plugins/ueberzug/init.lua
@@ -12,13 +12,13 @@ Ueberzug:
 
 Usage example:
     " If you are using ueberzugpp, you can have animated gif previews with this:
-    fileviewer {*.gif}
+    fileviewer <image/gif>
         \ #ueberzug#image_no_cache %px %py %pw %ph
         \ %pc
         \ #ueberzug#clear
 
     " Otherwise, use the video fileviewer for gifs
-    " fileviewer <video/*>,{*.gif}
+    " fileviewer <video/*>,<image/gif>
     fileviewer <video/*>
         \ #ueberzug#video %px %py %pw %ph
         \ %pc


### PR DESCRIPTION
Sometimes the file is actually `mp4`, but the extension is `gif`, which will cause the previewer to not work correctly. It's better not to rely on extensions when possible.