### PR TITLE
Cut the middle part of a long filename

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -7332,6 +7332,15 @@ right align (default)
   set viewcolumns={name}
 .EE
 .IP \- 2
+middle align
+
+It's like left alignment, but when the text is bigger than the column, it
+is cut in the middle (so the start and the end of the field are always visible).
+
+.EX
+  set viewcolumns=^{name}
+.EE
+.IP \- 2
 dynamic align
 
 It's like left alignment, but when the text is bigger than the column, the

--- a/src/ui/column_view.c
+++ b/src/ui/column_view.c
@@ -383,7 +383,12 @@ decorate_output(const column_t *col, char buf[], size_t buf_len,
 		return (col->info.align == AT_RIGHT ? AT_RIGHT : AT_LEFT);
 	}
 
-	if(col->info.align == AT_LEFT ||
+	if (col->info.align == AT_MIDDLE)
+	{
+		ellipsed = middle_ellipsis(buf, max_col_width, ell);
+		result = AT_LEFT;
+	}
+	else if(col->info.align == AT_LEFT ||
 			(col->info.align == AT_DYN && len <= max_col_width))
 	{
 		ellipsed = right_ellipsis(buf, max_col_width, ell);

--- a/src/ui/column_view.h
+++ b/src/ui/column_view.h
@@ -27,10 +27,13 @@
 /* Type of text alignment within a column. */
 typedef enum
 {
-	AT_LEFT,  /* Left alignment. */
-	AT_RIGHT, /* Right alignment. */
-	AT_DYN    /* Left alignment, if the text fits if the text is longer, make sure
-	             the end of field is always visible. */
+	AT_LEFT,   /* Left alignment. */
+	AT_RIGHT,  /* Right alignment. */
+	AT_MIDDLE, /* Left alignment, if the text fits if the text is longer, make sure
+	              the start and the end of field are always visible by cutting the
+	              text in the middle. */
+	AT_DYN     /* Left alignment, if the text fits if the text is longer, make sure
+	              the end of field is always visible. */
 }
 AlignType;
 

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -577,11 +577,17 @@ right_ellipsis(const char str[], size_t max_width, const char ell[])
 	return ellipsis(str, max_width, ell, 1);
 }
 
+char *
+middle_ellipsis(const char str[], size_t max_width, const char ell[])
+{
+	return ellipsis(str, max_width, ell, 2);
+}
+
 /* Ensures that str is of width (in character positions) less than or equal to
- * max_width and is aligned appropriately putting ellipsis on one of the ends if
- * needed.  Returns newly allocated modified string. */
+ * max_width and is aligned appropriately putting ellipsis on one of the ends or
+ * in the middle if needed.  Returns newly allocated modified string. */
 static char *
-ellipsis(const char str[], size_t max_width, const char ell[], int right)
+ellipsis(const char str[], size_t max_width, const char ell[], int ell_alignment)
 {
 	if(max_width == 0U)
 	{
@@ -604,12 +610,30 @@ ellipsis(const char str[], size_t max_width, const char ell[], int right)
 		return format_str("%.*s", prefix, ell);
 	}
 
-	if(right)
+	if(ell_alignment == 2)
 	{
+		/* Middle ellipsis */
+		const int prefix_width = max_width / 2 - ell_width / 2;
+
+		const int prefix = utf8_nstrsnlen(str, prefix_width);
+		const char *suffix = str + prefix;
+
+		while(width > max_width - ell_width)
+		{
+			width -= utf8_chrsw(suffix);
+			suffix += utf8_chrw(suffix);
+		}
+
+		return format_str("%.*s%s%s", prefix, str, ell, suffix);
+	}
+	else if(ell_alignment == 1)
+	{
+		/* Right ellipsis */
 		const int prefix = utf8_nstrsnlen(str, max_width - ell_width);
 		return format_str("%.*s%s", prefix, str, ell);
 	}
 
+	/* Left ellipsis */
 	while(width > max_width - ell_width)
 	{
 		width -= utf8_chrsw(str);

--- a/src/utils/str.h
+++ b/src/utils/str.h
@@ -203,6 +203,11 @@ char * left_ellipsis(const char str[], size_t max_width, const char ell[]);
  * Returns newly allocated modified string. */
 char * right_ellipsis(const char str[], size_t max_width, const char ell[]);
 
+/* Ensures that str is of width (in character positions) less than or equal to
+ * max_width and is left aligned putting ellipsis in the middle if needed.
+ * Returns newly allocated modified string. */
+char * middle_ellipsis(const char str[], size_t max_width, const char ell[]);
+
 /* "Breaks" single line it two parts (before and after separator), and
  * re-formats it filling specified width by putting "left part", padded centre
  * followed by "right part".  Frees the str.  Returns re-formatted string in

--- a/src/viewcolumns_parser.c
+++ b/src/viewcolumns_parser.c
@@ -189,6 +189,11 @@ parse_align(const char str[], column_info_t *info)
 		info->align = AT_DYN;
 		++str;
 	}
+	else if(*str == '^')
+	{
+		info->align = AT_MIDDLE;
+		++str;
+	}
 	return str;
 }
 

--- a/tests/column_view/align.c
+++ b/tests/column_view/align.c
@@ -212,5 +212,83 @@ TEST(dyn_align_on_the_right)
 	columns_free(cols);
 }
 
+TEST(middle_align)
+{
+	static column_info_t column_info = {
+		.column_id = COL1_ID, .full_width = 0UL, .text_width = 0UL,
+		.align = AT_MIDDLE,      .sizing = ST_AUTO, .cropping = CT_ELLIPSIS,
+	};
+
+	columns_t *const cols = columns_create();
+	col1_next = column1_func2;
+	columns_add_column(cols, column_info);
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 8);
+	assert_string_equal("abcdefg ", print_buffer);
+	assert_int_equal(AT_LEFT, last_align);
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 7);
+	assert_string_equal("abcdefg", print_buffer);
+	assert_int_equal(AT_LEFT, last_align);
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 6);
+	assert_string_equal("ab...g", print_buffer);
+	assert_int_equal(AT_LEFT, last_align);
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 5);
+	assert_string_equal("a...g", print_buffer);
+	assert_int_equal(AT_LEFT, last_align);
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 4);
+	assert_string_equal("a...", print_buffer);
+	assert_int_equal(AT_LEFT, last_align);
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 2);
+	assert_string_equal("..", print_buffer);
+	assert_int_equal(AT_LEFT, last_align);
+
+	columns_free(cols);
+}
+
+TEST(middle_align_on_the_right)
+{
+	static column_info_t column_info1 = {
+		.column_id = COL1_ID, .full_width = 0UL, .text_width = 0UL,
+		.align = AT_RIGHT,    .sizing = ST_AUTO, .cropping = CT_TRUNCATE,
+	};
+
+	static column_info_t column_info2 = {
+		.column_id = COL2_ID, .full_width = 0UL, .text_width = 0UL,
+		.align = AT_MIDDLE,      .sizing = ST_AUTO, .cropping = CT_TRUNCATE,
+	};
+
+	columns_t *const cols = columns_create();
+	columns_add_column(cols, column_info1);
+	columns_add_column(cols, column_info2);
+
+	col2_next = &column1_func2;
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 10);
+	assert_string_equal("aaaaaabefg", print_buffer);
+
+	col1_next = &column1_func2;
+	col2_next = &column2_func;
+
+	memset(print_buffer, '\0', MAX_WIDTH);
+	columns_format_line(cols, NULL, 16);
+	assert_string_equal(" abcdefgbxx     ", print_buffer);
+
+	col2_next = NULL;
+
+	columns_free(cols);
+}
+
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */
 /* vim: set cinoptions+=t0 filetype=c : */

--- a/tests/column_view/cropping.c
+++ b/tests/column_view/cropping.c
@@ -252,5 +252,50 @@ TEST(filling_is_done_per_column)
 	assert_string_equal(expected, print_buffer);
 }
 
+TEST(ellipsis_align_middle)
+{
+	static column_info_t column_infos[2] = {
+		{ .column_id = COL1_ID, .full_width = 15UL,    .text_width = 15UL,
+		  .align = AT_MIDDLE,     .sizing = ST_ABSOLUTE, .cropping = CT_ELLIPSIS, },
+		{ .column_id = COL2_ID, .full_width = 35UL,    .text_width = 35UL,
+		  .align = AT_MIDDLE,     .sizing = ST_ABSOLUTE, .cropping = CT_TRUNCATE, },
+	};
+	static const char expected[] = "aaaaaa...zzzzzzbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+	perform_test(column_infos, ARRAY_LEN(column_infos));
+
+	assert_string_equal(expected, print_buffer);
+}
+
+TEST(truncating_align_middle)
+{
+	static column_info_t column_infos[2] = {
+		{ .column_id = COL1_ID, .full_width = 15UL,    .text_width = 15UL,
+		  .align = AT_MIDDLE,     .sizing = ST_ABSOLUTE, .cropping = CT_NONE, },
+		{ .column_id = COL2_ID, .full_width = 35UL,    .text_width = 35UL,
+		  .align = AT_MIDDLE,     .sizing = ST_ABSOLUTE, .cropping = CT_TRUNCATE, },
+	};
+	static const char expected[] = "aaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbb";
+
+	perform_test(column_infos, ARRAY_LEN(column_infos));
+
+	assert_string_equal(expected, print_buffer);
+}
+
+TEST(none_align_middle)
+{
+	static column_info_t column_infos[2] = {
+		{ .column_id = COL1_ID, .full_width = 15UL,    .text_width = 15UL,
+		  .align = AT_MIDDLE,     .sizing = ST_ABSOLUTE, .cropping = CT_NONE, },
+		{ .column_id = COL2_ID, .full_width = 35UL,    .text_width = 35UL,
+		  .align = AT_RIGHT,    .sizing = ST_ABSOLUTE, .cropping = CT_NONE, },
+	};
+	static const char expected[] = "aaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+	perform_test(column_infos, ARRAY_LEN(column_infos));
+
+	assert_string_equal(expected, print_buffer);
+}
+
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */
 /* vim: set cinoptions+=t0 filetype=c : */

--- a/tests/column_view/utf8.c
+++ b/tests/column_view/utf8.c
@@ -227,6 +227,24 @@ TEST(wide_right_ellipsis_ok, IF(locale_works))
 	assert_string_equal(expected, print_buffer);
 }
 
+TEST(wide_middle_ellipsis_ok, IF(locale_works))
+{
+	/* A gap might appear after removing several characters to insert ellipsis in
+	 * their place, make sure that it's filled with spaces to obtain requested
+	 * width. */
+
+	static column_info_t column_infos[1] = {
+		{ .column_id = COL1_ID, .full_width = 0UL, .text_width = 0UL,
+		  .align = AT_MIDDLE,    .sizing = ST_AUTO, .cropping = CT_ELLIPSIS, },
+	};
+	static const char expected[] = ",,师从螺...从螺丝刀 ";
+
+	col1_str = ",,师从螺丝刀师从螺丝刀";
+	perform_test(column_infos, ARRAY_LEN(column_infos), MAX_WIDTH);
+
+	assert_string_equal(expected, print_buffer);
+}
+
 static int
 locale_works(void)
 {


### PR DESCRIPTION
I often find myself working with files that have long names and for which the beginning and end part is important. I implemented this as an alignment option, which is like left alignment but cuts off the middle part if the name is too long:

![image](https://github.com/vifm/vifm/assets/80581374/46a6dc25-9034-48b3-a15c-3e072773c6e1)


Closes #868
