### PR TITLE
Fix search match highlighting issues with handling lines with hidden parts

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -169,4 +169,5 @@ Marcin Kurczewski (a.k.a. rr-) fixed limited size of IPC buffer.
 
 voh9eepah fixed available file-system space size on FreeBSD.
 
-Vadim Curcă added middle ellipsis to view columns.
+Vadim Curcă added middle ellipsis to view columns and fixed search match
+highlighting when the match is cut off due lack of space.

--- a/BUGS
+++ b/BUGS
@@ -1,4 +1,3 @@
-* Middle ellipsis breaks search highlighting.
 * Better to check for existence of $HOME.
 * Duplicate detection lags in custom views on :substitute.
 * filextype is useless on OS X.
@@ -21,5 +20,3 @@
   doesn't work.
 * Access time of directories might not be preserved on OpenBSD on copying when
   'syscalls' is on, this is some subtle issue, because the code looks fine.
-* Search match highlighting has issues with handling hidden matched parts,
-  especially if 'tuioptions' contains "u".

--- a/ChangeLog
+++ b/ChangeLog
@@ -157,6 +157,9 @@
 	Fixed environment variables not being expanded on checking that a
 	:file[x]type or :fileviewer command exists.  Thanks to Ben Elan.
 
+	Fixed search match highlighting when the match is cut off due lack of
+	space.  Patch by Vadim Curcă.
+
 0.13-beta to 0.13 (2023-04-04)
 
 	Made "withicase" and "withrcase" affect how files are sorted before

--- a/src/ui/column_view.h
+++ b/src/ui/column_view.h
@@ -20,7 +20,6 @@
 #define VIFM__UI__COLUMN_VIEW_H__
 
 #include <stddef.h> /* size_t */
-#include "fileview.h"
 
 /* Special reserved column id for gap filling request. */
 #define FILL_COLUMN_ID ~0
@@ -63,10 +62,12 @@ typedef struct columns_t columns_t;
 typedef struct format_info_t format_info_t;
 struct format_info_t
 {
-	void *data;  /* User data passed to columns_format_line(). */
-	int id;      /* Id of the column or FILL_COLUMN_ID (pseudo-column). */
-	int real_id; /* Id of the column that is being printed/filled. */
-	int width;   /* Calculated width of the column. */
+	void *data;     /* User data passed to columns_format_line(). */
+	int id;         /* Id of the column or FILL_COLUMN_ID (pseudo-column). */
+	int real_id;    /* Id of the column that is being printed/filled. */
+	int width;      /* Calculated width of the column. */
+	int match_from; /* Start offset of the match, -1 for no match. */
+	int match_to;   /* End offset of the mat, -1 for no match. */
 };
 
 /* A column callback function, which should fill the buf with column text. */
@@ -78,7 +79,8 @@ typedef void (*column_func)(void *data, size_t buf_len, char buf[],
 typedef void (*column_line_print_func)(const char buf[], int offset,
 		AlignType align, const char full_column[], const format_info_t *info);
 /* A callback function that returns search match of the column via match_from
- * and match_to output parameters. */
+ * and match_to output parameters (no need to update them if there is no
+ * match). */
 typedef void (*column_line_match_func)(const char full_column[],
 		const format_info_t *info, int *match_from, int *match_to);
 
@@ -126,7 +128,7 @@ void columns_add_column(columns_t *cols, column_info_t info);
 void columns_clear(columns_t *cols);
 
 /* Performs actual formatting of columns. */
-void columns_format_line(columns_t *cols, column_data_t *format_data,
+void columns_format_line(columns_t *cols, void *format_data,
 		int max_line_width);
 
 /* Checks if recalculation is needed.  Returns non-zero if so, otherwise zero is

--- a/src/ui/column_view.h
+++ b/src/ui/column_view.h
@@ -77,6 +77,10 @@ typedef void (*column_func)(void *data, size_t buf_len, char buf[],
  * actual alignment of current column (AT_DYN won't appear here). */
 typedef void (*column_line_print_func)(const char buf[], int offset,
 		AlignType align, const char full_column[], const format_info_t *info);
+/* A callback function that returns search match of the column via match_from
+ * and match_to output parameters. */
+typedef void (*column_line_match_func)(const char full_column[],
+		const format_info_t *info, int *match_from, int *match_to);
 
 /* Structure containing various column display properties. */
 typedef struct
@@ -91,8 +95,11 @@ typedef struct
 }
 column_info_t;
 
-/* Registers column print function. */
+/* Registers column print function (required to use this unit). */
 void columns_set_line_print_func(column_line_print_func func);
+
+/* Registers column match function (optional). */
+void columns_set_line_match_func(column_line_match_func func);
 
 /* Sets string to be used in place of ellipsis.  The argument is used directly,
  * no copy is made. */

--- a/src/ui/column_view.h
+++ b/src/ui/column_view.h
@@ -20,6 +20,7 @@
 #define VIFM__UI__COLUMN_VIEW_H__
 
 #include <stddef.h> /* size_t */
+#include "fileview.h"
 
 /* Special reserved column id for gap filling request. */
 #define FILL_COLUMN_ID ~0
@@ -118,7 +119,7 @@ void columns_add_column(columns_t *cols, column_info_t info);
 void columns_clear(columns_t *cols);
 
 /* Performs actual formatting of columns. */
-void columns_format_line(columns_t *cols, void *format_data,
+void columns_format_line(columns_t *cols, column_data_t *format_data,
 		int max_line_width);
 
 /* Checks if recalculation is needed.  Returns non-zero if so, otherwise zero is

--- a/src/ui/fileview.c
+++ b/src/ui/fileview.c
@@ -121,6 +121,7 @@ static void compute_and_draw_cell(column_data_t *cdt, int cell,
 static void column_line_print(const char buf[], int offset, AlignType align,
 		const char full_column[], const format_info_t *info);
 static void draw_line_number(const column_data_t *cdt, int column);
+static int is_primary_column_id(int id);
 static void highlight_search(view_t *view, const char full_column[], char buf[],
 		size_t buf_len, AlignType align, int line, int col,
 		const cchar_t *line_attrs, int match_from, int match_to);
@@ -1181,13 +1182,7 @@ column_line_print(const char buf[], int offset, AlignType align,
 	const int numbers_visible = (offset == 0 && cdt->number_width > 0);
 	const int padding = (cfg.extra_padding != 0);
 
-	const int primary = info->id == SK_BY_NAME
-	                 || info->id == SK_BY_INAME
-	                 || info->id == SK_BY_ROOT
-	                 || info->id == SK_BY_FILEROOT
-	                 || info->id == SK_BY_EXTENSION
-	                 || info->id == SK_BY_FILEEXT
-	                 || vlua_viewcolumn_is_primary(curr_stats.vlua, info->id);
+	const int primary = is_primary_column_id(info->id);
 	const cchar_t line_attrs =
 		prepare_col_color(view, primary, 0, cdt, info->real_id);
 
@@ -1283,6 +1278,20 @@ draw_line_number(const column_data_t *cdt, int column)
 	checked_wmove(view->win, cdt->current_line, column);
 	cchar_t cch = prepare_col_color(view, 0, 1, cdt, /*real_id=*/-1);
 	wprinta(view->win, num_str, &cch, 0);
+}
+
+/* Checks whether column id corresponds to a column that displays part of
+ * entry's path or name.  Returns non-zero if so. */
+static int
+is_primary_column_id(int id)
+{
+	return id == SK_BY_NAME
+	    || id == SK_BY_INAME
+	    || id == SK_BY_ROOT
+	    || id == SK_BY_FILEROOT
+	    || id == SK_BY_EXTENSION
+	    || id == SK_BY_FILEEXT
+	    || vlua_viewcolumn_is_primary(curr_stats.vlua, id);
 }
 
 /* Highlights search match for the entry (assumed to be a search hit).  Modifies

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -604,7 +604,7 @@ void
 get_middle_cut_range(const char str[], size_t max_width, size_t* cut_from, size_t* cut_to)
 {
 	size_t width = utf8_strsw(str);
-	const size_t prefix_width = max_width/2;
+	const size_t prefix_width = (max_width+1)/2;
 
 	const size_t prefix = utf8_nstrsnlen(str, prefix_width);
 	const char *suffix = str + prefix;

--- a/src/utils/str.c
+++ b/src/utils/str.c
@@ -575,7 +575,8 @@ stralign(char str[], size_t width, char pad, int left_align)
 }
 
 void
-get_left_cut_range(const char str[], size_t max_width, size_t* cut_from, size_t* cut_to)
+get_left_cut_range(const char str[], size_t max_width, size_t *cut_from,
+		size_t *cut_to)
 {
 	size_t width = utf8_strsw(str);
 	const char *suffix = str;
@@ -591,7 +592,8 @@ get_left_cut_range(const char str[], size_t max_width, size_t* cut_from, size_t*
 }
 
 void
-get_right_cut_range(const char str[], size_t max_width, size_t* cut_from, size_t* cut_to)
+get_right_cut_range(const char str[], size_t max_width, size_t *cut_from,
+		size_t *cut_to)
 {
 	const size_t prefix = utf8_nstrsnlen(str, max_width);
 
@@ -599,12 +601,12 @@ get_right_cut_range(const char str[], size_t max_width, size_t* cut_from, size_t
 	*cut_to = strlen(str);
 }
 
-
 void
-get_middle_cut_range(const char str[], size_t max_width, size_t* cut_from, size_t* cut_to)
+get_middle_cut_range(const char str[], size_t max_width, size_t *cut_from,
+		size_t *cut_to)
 {
 	size_t width = utf8_strsw(str);
-	const size_t prefix_width = (max_width+1)/2;
+	const size_t prefix_width = (max_width + 1)/2;
 
 	const size_t prefix = utf8_nstrsnlen(str, prefix_width);
 	const char *suffix = str + prefix;

--- a/src/utils/str.h
+++ b/src/utils/str.h
@@ -193,6 +193,21 @@ int sstrappend(char str[], size_t *len, size_t size, const char suffix[]);
 /* Pads buffer pointed to by str to be at least of width "width + 1". */
 void stralign(char str[], size_t width, char pad, int left_align);
 
+/* Get left and right offsets needed to cut str on the left side and ensure its
+ * width is (in character positions) less than or equal to max_width. */
+void get_left_cut_range(const char str[], size_t max_width, size_t *cut_from,
+                        size_t *cut_to);
+
+/* Get left and right offsets needed to cut str on the right side and ensure its
+ * width is (in character positions) less than or equal to max_width. */
+void get_right_cut_range(const char str[], size_t max_width, size_t *cut_from,
+                         size_t *cut_to);
+
+/* Get left and right offsets needed to cut str in the middle and ensure its
+ * width is (in character positions) less than or equal to max_width. */
+void get_middle_cut_range(const char str[], size_t max_width, size_t *cut_from,
+                          size_t *cut_to);
+
 /* Ensures that str is of width (in character positions) less than or equal to
  * max_width and is right aligned putting ellipsis on the left side if needed.
  * Returns newly allocated modified string. */

--- a/src/utils/str.h
+++ b/src/utils/str.h
@@ -196,17 +196,17 @@ void stralign(char str[], size_t width, char pad, int left_align);
 /* Get left and right offsets needed to cut str on the left side and ensure its
  * width is (in character positions) less than or equal to max_width. */
 void get_left_cut_range(const char str[], size_t max_width, size_t *cut_from,
-                        size_t *cut_to);
+		size_t *cut_to);
 
 /* Get left and right offsets needed to cut str on the right side and ensure its
  * width is (in character positions) less than or equal to max_width. */
 void get_right_cut_range(const char str[], size_t max_width, size_t *cut_from,
-                         size_t *cut_to);
+		size_t *cut_to);
 
 /* Get left and right offsets needed to cut str in the middle and ensure its
  * width is (in character positions) less than or equal to max_width. */
 void get_middle_cut_range(const char str[], size_t max_width, size_t *cut_from,
-                          size_t *cut_to);
+		size_t *cut_to);
 
 /* Ensures that str is of width (in character positions) less than or equal to
  * max_width and is right aligned putting ellipsis on the left side if needed.

--- a/tests/column_view/align.c
+++ b/tests/column_view/align.c
@@ -7,8 +7,8 @@
 #include "../../src/ui/column_view.h"
 #include "test.h"
 
-static void column_line_print(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
+static void column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
 static void column1_func(void *data, size_t buf_len, char buf[],
 		const format_info_t *info);
 static void column2_func(void *data, size_t buf_len, char buf[],
@@ -33,10 +33,10 @@ TEARDOWN()
 }
 
 static void
-column_line_print(const void *data, int column_id, const char buf[], int offset,
-		AlignType align)
+column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
-	if(column_id == COL1_ID)
+	if(info->real_id == COL1_ID)
 	{
 		last_align = align;
 	}

--- a/tests/column_view/align.c
+++ b/tests/column_view/align.c
@@ -276,7 +276,7 @@ TEST(middle_align_on_the_right)
 
 	memset(print_buffer, '\0', MAX_WIDTH);
 	columns_format_line(cols, NULL, 10);
-	assert_string_equal("aaaaaabefg", print_buffer);
+	assert_string_equal("aaaaaabcfg", print_buffer);
 
 	col1_next = &column1_func2;
 	col2_next = &column2_func;

--- a/tests/column_view/callbacks.c
+++ b/tests/column_view/callbacks.c
@@ -6,8 +6,8 @@
 
 #include "test.h"
 
-static void column_line_print(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
+static void column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
 static void columns_func(void *data, size_t buf_len, char buf[],
 		const format_info_t *info);
 
@@ -53,8 +53,8 @@ TEARDOWN()
 }
 
 static void
-column_line_print(const void *data, int column_id, const char buf[], int offset,
-		AlignType align)
+column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
 	++print_counter;
 }

--- a/tests/column_view/cropping.c
+++ b/tests/column_view/cropping.c
@@ -12,10 +12,10 @@
 static const size_t MAX_WIDTH = 40;
 static char print_buffer[40 + 1];
 
-static void column_line_print(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
-static void filler_print(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
+static void column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
+static void filler_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
 static void column1_func(void *data, size_t buf_len, char buf[],
 		const format_info_t *info);
 static void column2_func(void *data, size_t buf_len, char buf[],
@@ -38,18 +38,18 @@ TEARDOWN()
 }
 
 static void
-column_line_print(const void *data, int column_id, const char buf[], int offset,
-		AlignType align)
+column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
 	memcpy(print_buffer + offset, buf, strlen(buf));
 }
 
 static void
-filler_print(const void *data, int column_id, const char buf[], int offset,
-		AlignType align)
+filler_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
 	int buf_len = strlen(buf);
-	memset(print_buffer + offset, '0' + column_id, buf_len);
+	memset(print_buffer + offset, '0' + info->real_id, buf_len);
 	print_buffer[offset + buf_len] = '\0';
 }
 

--- a/tests/column_view/general.c
+++ b/tests/column_view/general.c
@@ -6,8 +6,8 @@
 
 #include "test.h"
 
-static void print_not_less_than_zero(const void *data, int column_id,
-		const char buf[], int offset, AlignType align);
+static void print_not_less_than_zero(const char buf[], int offset,
+		AlignType align, const format_info_t *info);
 static void column12_func(void *data, size_t buf_len, char buf[],
 		const format_info_t *info);
 
@@ -43,8 +43,8 @@ TEARDOWN()
 }
 
 static void
-print_not_less_than_zero(const void *data, int column_id, const char buf[],
-		int offset, AlignType align)
+print_not_less_than_zero(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
 	assert_true(offset <= MAX_WIDTH);
 }

--- a/tests/column_view/highlighting.c
+++ b/tests/column_view/highlighting.c
@@ -1,0 +1,174 @@
+#include <stic.h>
+
+#include <stddef.h> /* NULL size_t */
+#include <stdio.h> /* snprintf() */
+#include <string.h> /* memcpy() memset() */
+
+#include "../../src/ui/column_view.h"
+#include "../../src/utils/macros.h"
+
+#include "test.h"
+
+enum { MAX_WIDTH = 10 };
+
+static void column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
+static void column_line_match(const char full_column[],
+		const format_info_t *info, int *match_from, int *match_to);
+static void column_five_as_zs(void *data, size_t buf_len, char buf[],
+		const format_info_t *info);
+static void column_many_bs(void *data, size_t buf_len, char buf[],
+		const format_info_t *info);
+static void perform_test(const column_info_t *column_info,
+		const char printed[], const char highlighted[]);
+
+static char print_buffer[MAX_WIDTH + 1];
+static char match_buffer[MAX_WIDTH + 1];
+static int match_start, match_end;
+
+SETUP()
+{
+	print_next = &column_line_print;
+	match_next = &column_line_match;
+	col1_next = &column_five_as_zs;
+	col2_next = &column_many_bs;
+}
+
+TEARDOWN()
+{
+	print_next = NULL;
+	match_next = NULL;
+	col1_next = NULL;
+	col2_next = NULL;
+}
+
+TEST(match_fits)
+{
+	static column_info_t column_info = {
+		.column_id = COL1_ID, .full_width = 10UL,    .text_width = 10UL,
+		.align = AT_LEFT,     .sizing = ST_ABSOLUTE, .cropping = CT_TRUNCATE,
+	};
+
+	match_start = 0, match_end = 5;
+	perform_test(&column_info, "aaaaazzzzz",
+	                           "*****     ");
+
+	match_start = 5, match_end = 10;
+	perform_test(&column_info, "aaaaazzzzz",
+	                           "     *****");
+
+	match_start = 3, match_end = 8;
+	perform_test(&column_info, "aaaaazzzzz",
+	                           "   *****  ");
+}
+
+TEST(match_on_the_right_cut_out)
+{
+	static column_info_t column_info = {
+		.column_id = COL1_ID, .full_width = 8UL,     .text_width = 8UL,
+		.align = AT_LEFT,     .sizing = ST_ABSOLUTE, .cropping = CT_TRUNCATE,
+	};
+
+	match_start = 0, match_end = 5;
+	perform_test(&column_info, "aaaaazzz  ",
+	                           "*****     ");
+
+	match_start = 5, match_end = 10;
+	perform_test(&column_info, "aaaaa>>>  ",
+	                           "     ***  ");
+
+	match_start = 3, match_end = 8;
+	perform_test(&column_info, "aaaaazzz  ",
+	                           "   *****  ");
+}
+
+TEST(match_on_the_left_cut_out)
+{
+	static column_info_t column_info = {
+		.column_id = COL1_ID, .full_width = 8UL,     .text_width = 8UL,
+		.align = AT_RIGHT,    .sizing = ST_ABSOLUTE, .cropping = CT_TRUNCATE,
+	};
+
+	match_start = 0, match_end = 5;
+	perform_test(&column_info, "<<<zzzzz  ",
+	                           "***       ");
+
+	match_start = 5, match_end = 10;
+	perform_test(&column_info, "aaazzzzz  ",
+	                           "   *****  ");
+
+	match_start = 3, match_end = 8;
+	perform_test(&column_info, "aaazzzzz  ",
+	                           " *****    ");
+}
+
+TEST(match_in_the_middle_cut_out)
+{
+	static column_info_t column_info = {
+		.column_id = COL1_ID, .full_width = 8UL,     .text_width = 8UL,
+		.align = AT_MIDDLE,   .sizing = ST_ABSOLUTE, .cropping = CT_TRUNCATE,
+	};
+
+	match_start = 0, match_end = 5;
+	perform_test(&column_info, "aa>..<zz  ",
+	                           "******    ");
+
+	match_start = 5, match_end = 10;
+	perform_test(&column_info, "aa>..<zz  ",
+	                           "  ******  ");
+
+	match_start = 3, match_end = 8;
+	perform_test(&column_info, "aa>..<zz  ",
+	                           "  ****    ");
+}
+
+static void
+column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
+{
+	memcpy(print_buffer + offset, buf, strlen(buf));
+	memset(match_buffer + info->match_from, '*',
+			info->match_to - info->match_from);
+}
+
+static void
+column_line_match(const char full_column[], const format_info_t *info,
+		int *match_from, int *match_to)
+{
+	*match_from = match_start;
+	*match_to = match_end;
+}
+
+static void
+column_five_as_zs(void *data, size_t buf_len, char buf[],
+		const format_info_t *info)
+{
+	snprintf(buf, buf_len + 1, "%s", "aaaaazzzzz");
+}
+
+static void
+column_many_bs(void *data, size_t buf_len, char buf[],
+		const format_info_t *info)
+{
+	snprintf(buf, buf_len + 1, "%s", "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+}
+
+static void
+perform_test(const column_info_t *column_info, const char printed[],
+		const char highlighted[])
+{
+	columns_t *const cols = columns_create();
+	columns_add_column(cols, *column_info);
+
+	memset(print_buffer, ' ', MAX_WIDTH);
+	memset(match_buffer, ' ', MAX_WIDTH);
+	columns_format_line(cols, NULL, MAX_WIDTH);
+
+	columns_free(cols);
+
+	assert_string_equal(printed, print_buffer);
+	assert_string_equal(highlighted, match_buffer);
+}
+
+/* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */
+/* vim: set cinoptions+=t0 filetype=c : */

--- a/tests/column_view/literals.c
+++ b/tests/column_view/literals.c
@@ -7,8 +7,8 @@
 #include "../../src/ui/column_view.h"
 #include "test.h"
 
-static void column_line_print(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
+static void column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
 
 static const size_t MAX_WIDTH = 80;
 
@@ -27,8 +27,8 @@ TEARDOWN()
 }
 
 static void
-column_line_print(const void *data, int column_id, const char buf[], int offset,
-		AlignType align)
+column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
 	print_offset = offset;
 	memcpy(print_buffer + offset, buf, strlen(buf));

--- a/tests/column_view/suite.c
+++ b/tests/column_view/suite.c
@@ -8,6 +8,8 @@
 
 static void column_line_print(const char buf[], int offset, AlignType align,
 		const char full_column[], const format_info_t *info);
+static void column_line_match(const char full_column[],
+		const format_info_t *info, int *match_from, int *match_to);
 static void column1_func(void *data, size_t buf_len, char buf[],
 		const format_info_t *info);
 static void column2_func(void *data, size_t buf_len, char buf[],
@@ -19,6 +21,7 @@ SETUP()
 {
 	columns_set_ellipsis("...");
 	columns_set_line_print_func(&column_line_print);
+	columns_set_line_match_func(&column_line_match);
 	assert_int_equal(0, columns_add_column_desc(COL1_ID, &column1_func, NULL));
 	assert_int_equal(0, columns_add_column_desc(COL2_ID, &column2_func, NULL));
 }
@@ -33,7 +36,17 @@ column_line_print(const char buf[], int offset, AlignType align,
 		const char full_column[], const format_info_t *info)
 {
 	assert_non_null(print_next);
-	print_next(info->data, info->real_id, buf, offset, align);
+	print_next(buf, offset, align, info);
+}
+
+static void
+column_line_match(const char full_column[], const format_info_t *info,
+		int *match_from, int *match_to)
+{
+	if(match_next != NULL)
+	{
+		match_next(full_column, info, match_from, match_to);
+	}
 }
 
 static void

--- a/tests/column_view/test.h
+++ b/tests/column_view/test.h
@@ -7,12 +7,13 @@
 #define COL2_ID 2
 
 /* This is version of column_line_print_func with fewer number of parameters.
- * Omitted those which are provide additional information and do not very
- * valuable in tests. */
-typedef void (*print_func)(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
+ * Omitted those which are provide additional information and are not very
+ * valuable for tests. */
+typedef void (*print_func)(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
 
 print_func print_next;
+column_line_match_func match_next;
 
 column_func col1_next;
 column_func col2_next;

--- a/tests/column_view/utf8.c
+++ b/tests/column_view/utf8.c
@@ -10,8 +10,8 @@
 
 #include "test.h"
 
-static void column_line_print(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
+static void column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
 static void column1_func(void *data, size_t buf_len, char buf[],
 		const format_info_t *info);
 static void column2_func(void *data, size_t buf_len, char buf[],
@@ -49,8 +49,8 @@ TEARDOWN()
 }
 
 static void
-column_line_print(const void *data, int column_id, const char buf[], int offset,
-		AlignType align)
+column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
 	memcpy(print_buffer + utf8_nstrsnlen(print_buffer, offset), buf, strlen(buf));
 }

--- a/tests/column_view/width.c
+++ b/tests/column_view/width.c
@@ -7,8 +7,8 @@
 #include "../../src/ui/column_view.h"
 #include "test.h"
 
-static void column_line_print(const void *data, int column_id, const char buf[],
-		int offset, AlignType align);
+static void column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info);
 static void column1_func(void *data, size_t buf_len, char buf[],
 		const format_info_t *info);
 static void column2_func(void *data, size_t buf_len, char buf[],
@@ -32,8 +32,8 @@ TEARDOWN()
 }
 
 static void
-column_line_print(const void *data, int column_id, const char buf[], int offset,
-		AlignType align)
+column_line_print(const char buf[], int offset, AlignType align,
+		const format_info_t *info)
 {
 	memcpy(print_buffer + offset, buf, strlen(buf));
 }

--- a/tests/misc/flist_misc.c
+++ b/tests/misc/flist_misc.c
@@ -372,20 +372,20 @@ TEST(fentry_get_recalculates_size)
 	copy_file(TEST_DATA_PATH "/various-sizes/block-size-file",
 			SANDBOX_PATH "/dir/file");
 	WAIT_FOR((dir.mtime += 1000, fentry_get_size(&lwin, &dir) == 8192),
-			50/*ms*/);
+			100/*ms*/);
 	assert_ulong_equal(8192, fentry_get_size(&lwin, &dir));
 	assert_ulong_equal(0, fentry_get_size(&lwin, &subdir));
 
 	copy_file(TEST_DATA_PATH "/various-sizes/block-size-file",
 			SANDBOX_PATH "/dir/subdir/file");
 	WAIT_FOR((subdir.mtime += 1000, fentry_get_size(&lwin, &subdir) == 8192),
-			50/*ms*/);
+			100/*ms*/);
 	assert_ulong_equal(8192, fentry_get_size(&lwin, &subdir));
 	assert_ulong_equal(16384, fentry_get_size(&lwin, &dir));
 
 	assert_success(remove(SANDBOX_PATH "/dir/subdir/file"));
 	WAIT_FOR((subdir.mtime += 1000, fentry_get_size(&lwin, &subdir) == 0),
-			50/*ms*/);
+			100/*ms*/);
 	assert_ulong_equal(0, fentry_get_size(&lwin, &subdir));
 	assert_ulong_equal(8192, fentry_get_size(&lwin, &dir));
 

--- a/tests/test-support/test-utils.c
+++ b/tests/test-support/test-utils.c
@@ -305,6 +305,7 @@ columns_teardown(void)
 {
 	columns_clear_column_descs();
 	columns_set_line_print_func(NULL);
+	columns_set_line_match_func(NULL);
 }
 
 void


### PR DESCRIPTION
I have moved the code for adjusting the search match ranges closer to where the line is cut and decorated. I fixed the issues I noticed at the beginning, but if there are still issues I didn't notice or you have change suggestions, let me know.