### PR TITLE
Fix handling of external commands starting with `-`

### DIFF
--- a/src/utils/utils_nix.c
+++ b/src/utils/utils_nix.c
@@ -358,7 +358,7 @@ make_execv_array(char shell[], char shell_flag[], char cmd[])
 
 	char name[NAME_MAX + 1];
 
-	char **args = reallocarray(NULL, 4 + npieces + 1, sizeof(*args));
+	char **args = reallocarray(NULL, 5 + npieces + 1, sizeof(*args));
 	char *eval_cmd;
 	size_t len;
 	size_t i;
@@ -376,6 +376,7 @@ make_execv_array(char shell[], char shell_flag[], char cmd[])
 			args[i++] = sh_arg;
 		}
 		args[i++] = shell_flag;
+		args[i++] = "--";
 		args[i++] = cmd;
 		args[i++] = NULL;
 		return args;


### PR DESCRIPTION
Currently, at least with bash and zsh, vifm is unable to run a command whose name starts with a dash (`-`) inside of a `term()` or `system()` call:

    zsh: bad option string: '-fd-compgen <...>'

Fix this by applying the idiomatic `--` guard to the shell invocation (by convention and by POSIX, `--` denotes end of options).