### PR TITLE
make ctrl-z remappable in user land

### DIFF
--- a/src/event_loop.c
+++ b/src/event_loop.c
@@ -210,7 +210,7 @@ event_loop(const int *quit, int manage_marking)
 				}
 			}
 
-			if(c == WC_C_z)
+			if(c == WC_C_z && !vle_keys_user_exists(WK_C_z, vle_mode_get()))
 			{
 				instance_stop();
 				continue;

--- a/tests/misc/event_loop.c
+++ b/tests/misc/event_loop.c
@@ -5,6 +5,7 @@
 #include "../../src/cfg/config.h"
 #include "../../src/engine/cmds.h"
 #include "../../src/engine/keys.h"
+#include "../../src/engine/mode.h"
 #include "../../src/lua/vlua.h"
 #include "../../src/modes/modes.h"
 #include "../../src/modes/wk.h"
@@ -53,6 +54,20 @@ TEST(quit_on_key_press)
 	vle_keys_add(&keys, 1U, NORMAL_MODE);
 
 	feed_keys(L"x");
+
+	quit = 0;
+	event_loop(&quit, /*manage_marking=*/1);
+}
+
+TEST(quit_on_key_press_user_defined_ctrl_z)
+{
+	key_conf_t key = { { &x_key} };
+	assert_success(vle_keys_foreign_add(WK_C_z, &key, /*is_selector=*/0,
+				NORMAL_MODE));
+	assert_true(vle_mode_get() == NORMAL_MODE);
+	assert_true(vle_keys_user_exists(WK_C_z, NORMAL_MODE));
+
+	feed_keys(WK_C_z);
 
 	quit = 0;
 	event_loop(&quit, /*manage_marking=*/1);


### PR DESCRIPTION
hi, while trying to figure out a way for #1007, i found that `<c-z>` has been hard-coded in event_loop::get_char_async_loop.

after read the context of get_char_async_loop, i think there is no particular reason to object  on making ctrl-z remappable in user land, so i made this PR.

the real usecase is that i have a plugin which runs vifm in a neovim's terminal buffer, and i want to add a keymap to vifm that informs nvim to hide the terminal buffer. as a proof of concept, i have already made this 'hidding functionality' work with [lhs-<space>.](https://github.com/haolian9/reveal.nvim/blob/master/lua/reveal/vifm/reveal/init.lua#L104).