### PR TITLE
src/int/term_title.c: : fix build against -std=c23 (`void (*)()`) cha…

### DIFF
--- a/src/int/term_title.c
+++ b/src/int/term_title.c
@@ -358,7 +358,7 @@ get_x11_disp_and_win(Display **disp, Window *win)
 static void
 get_x11_window_title(Display *disp, Window win, char *buf, size_t buf_len)
 {
-	int (*old_handler)();
+	int (*old_handler)(Display *, XErrorEvent *);
 	XTextProperty text_prop;
 
 	old_handler = XSetErrorHandlerWrapper(x_error_check);


### PR DESCRIPTION
…nged the meaning)

gcc-15 switched to -std=c23 by default:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212

As a result `vifm` fails the build as:

    int/term_title.c: In function 'get_x11_window_title':
    int/term_title.c:364:21: error:
      assignment to 'int (*)(void)' from incompatible pointer type 'XErrorHandler' {aka 'int (*)(Display *, XErrorEvent *)'} [-Wincompatible-pointer-types-Wincompatible-pointer-types]
      364 |         old_handler = XSetErrorHandlerWrapper(x_error_check);
          |                     ^
    int/term_title.c:367:47: error:
      passing argument 1 of 'XSetErrorHandlerWrapper' from incompatible pointer type [-Wincompatible-pointer-types]
      367 |                 (void)XSetErrorHandlerWrapper(old_handler);
          |                                               ^~~~~~~~~~~
          |                                               |
          |                                               int (*)(void)

The changes fully specifies `old_handler` type.