### PR TITLE
Fix AppStream metadata id and screenshot tag

### DIFF
--- a/data/vifm.appdata.xml
+++ b/data/vifm.appdata.xml
@@ -13,11 +13,13 @@
 
 	<launchable type="desktop-id">vifm.desktop</launchable>
 
-	<screenshot type="default">
-		<image>
-			https://raw.githubusercontent.com/vifm/vifm/master/data/graphics/screenshot.png
-		</image>
-	</screenshot>
+	<screenshots>
+		<screenshot type="default">
+			<image>
+				https://raw.githubusercontent.com/vifm/vifm/master/data/graphics/screenshot.png
+			</image>
+		</screenshot>
+	</screenshots>
 
 	<url type="homepage">https://vifm.info/</url>
 	<update_contact>xaizek@posteo.net</update_contact>

--- a/data/vifm.appdata.xml
+++ b/data/vifm.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
-	<id>info.vifm</id>
+	<id>info.vifm.vifm</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-2.0-or-later</project_license>
 	<name>Vifm</name>


### PR DESCRIPTION
It should be in valid rDNS format:

https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-id-generic

Fixes:

```
$ appstreamcli validate vifm.appdata.xml
W: info.vifm:3: cid-desktopapp-is-not-rdns info.vifm
...
```

Also fix the incorrect "screenshot" tag:

```
I: info.vifm.vifm:16: unknown-tag screenshot
```