### PR TITLE
vifm.1: Fix typos/warnings

### DIFF
--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -74,7 +74,7 @@ added has the highest priority.
 .TP
 .BI "\-\-logging[=<startup log path>]"
 Log some operational details to $XDG_DATA_HOME/vifm/log or $VIFM/log.  If
-the optional startup log path is specified and permissions allow to open
+the optional startup log path is specified and permissions allow one to open
 it for writing, then logging of early initialization (before configuration
 directories are determined) is put there.
 .TP
@@ -1429,7 +1429,7 @@ However, there are several exceptions:
 .RE
 
 \(aq|\(aq can be used to separate commands, so you can give multiple commands in one
-line.  If you want to use '|' in an argument, precede it with '\\'.
+line.  If you want to use '|' in an argument, precede it with '\e'.
 
 These commands see '|' as part of their arguments even when it's escaped:
 
@@ -2339,7 +2339,7 @@ Available colors:
  \- 0-255 \- corresponding colors from 256-color palette (for ctermfg and \
 ctermbg)
  \- #rrggbb \- direct ("gui", "true", 24-bit) color in hex-notation, each of \
-the three compontents are in the range 0x00 to 0xff (for guifg and guibg)
+the three components are in the range 0x00 to 0xff (for guifg and guibg)
 
 Light versions of colors are regular colors with bold attribute set
 automatically in terminals that have less than 16 colors.  So order of arguments
@@ -2934,7 +2934,7 @@ detach current session without saving it.  Resets v:session.
 .BI ":session name"
 create or load and switch to a session with the specified name.  Name
 can't contain slashes.  Session active at the moment is saved before the
-switch.  Session is also automatically saved when quiting the application in
+switch.  Session is also automatically saved when quitting the application in
 usual ways.  Sets v:session.
 .TP
 .BI ":session -"
@@ -6303,7 +6303,7 @@ Checks type of a view's entry or of a file specified by its path.
 Parameter {file} can be of the following forms:
  \- '.' to get type of file under the cursor in the active pane
  \- numerical value base 1 to get type of file on specified line number (only
-\if there are no charactes other than "+-0123456789")
+\if there are no characters other than "+-0123456789")
  \- a path (prepend "./" to force interpretation of a number or '.' as a path)
 
 Optional parameter {resolve} is treated as a boolean and specifies whether
@@ -6917,7 +6917,7 @@ Re-opening the last viewed menu of relevant type is done by running
 menus and :cnewer to view newer ones.
 
 Closing a menu after moving through the history remembers the position such
-that running :copen again will open the last viewed menu and allow to
+that running :copen again will open the last viewed menu and allow one to
 continue exploring history in both directions.
 
 The history always contains menus sorted from oldest to newest.  After opening


### PR DESCRIPTION
Hi, I'm the maintainer of the vifm package in Debian and I noticed some typos and warnings in the manual using the Lintian tool. Have a good day!