### PR TITLE
Add xaizek examples to README.md

### DIFF
--- a/README
+++ b/README
@@ -59,3 +59,7 @@ Contacts
     * https://github.com/cirala/vifmimg
     * https://github.com/eylles/vifm-sixel-preview
     * https://github.com/iambumblehead/thu.sh
+
+    xaizek examples:
+    * https://github.com/xaizek/dotvifm
+    * https://github.com/xaizek/dotfiles


### PR DESCRIPTION
In one of the issues you shared a part of your configuration with me. Later I forgot about it and couldn't remember where it was, but eventually I found it again. Your configuration contains many useful tricks for vifm, so I think it would be helpful to include it in the README.

I made a slight mistake with the pull request name; it shouldn't have md in it.