### PR TITLE
Add .deb handlers examples in the data/vifmrc

### DIFF
--- a/data/vifmrc
+++ b/data/vifmrc
@@ -460,6 +460,10 @@ filextype */
         \ {View in thunar}
         \ Thunar %f &,
 
+" Deb packages
+fileviewer *.deb dpkg-deb -I %c; echo; dpkg-deb -c %c
+filetype *.deb echo "$(dpkg-deb -I %c; echo; dpkg-deb -c %c)" | less
+
 " Syntax highlighting in preview
 "
 " Explicitly set highlight type for some extensions


### PR DESCRIPTION
I found an extremely helpful thing for Debian users. I couldn’t figure out for a long time how to replicate the behavior of Midnight Commander, where pressing F3 views detailed package information. I was able to write a filetype handler command that reproduces this behavior in vifm, and I think it would be useful to include it as an example.