### PR TITLE
refactor: run `git status -z` asynchronously to not block directory traversal

### DIFF
--- a/data/plugins/git/README.md
+++ b/data/plugins/git/README.md
@@ -98,7 +98,6 @@ similar to how `git status --short` does it.
 
 **TODO:**
 
- * Run `git status -z` asynchronously to not block directory traversal.
  * Make cache update faster if directory modification is detected.
  * Check behaviour with submodules.
  * Check if `!!` status can ever be seen.

--- a/data/plugins/git/README.md
+++ b/data/plugins/git/README.md
@@ -99,7 +99,6 @@ similar to how `git status --short` does it.
 **TODO:**
 
  * Make cache update faster if directory modification is detected.
- * Check behaviour with submodules.
  * Check if `!!` status can ever be seen.
  * Consider using `git status --porcelain=v2 -z` as it provides more
    information.

--- a/data/plugins/git/README.md
+++ b/data/plugins/git/README.md
@@ -57,7 +57,7 @@ similar to how `git status --short` does it.
 
 | Value | Meaning
 | ----- | -------
-| `  `  | Ignored or unchanged.
+| `  `  | Ignored.
 | ` M`  | Modified in worktree.
 | `MM`  | Modified in index and in worktree.
 | `AM`  | Added in index, modified in worktree.
@@ -74,6 +74,7 @@ similar to how `git status --short` does it.
 | `DU`  | Deleted here, but updated in merged changes.
 | `AA`  | Added here and in merged changes.
 | `UU`  | Modified here and in merged changes.
+| `GG`  | Unchanged.
 | `??`  | Untracked.
 
 **Possible column values for directories:**
@@ -93,13 +94,16 @@ similar to how `git status --short` does it.
 
 **Issues:**
 
- * Has a noticeable initial delay for large Git repositories due to fetching
-   statuses synchronously.
+ * Large repositories won't show complete status due to hitting pipe size limit.
+ * Git status for a submodule isn't fetched immediately after entering it.
 
 **TODO:**
 
- * Address obtaining GG entries failing for large repositories due to filling
-   of the pipe before `onexit` callback in invoked.
+ * Could add `:Gopt` to make some behaviour optional:
+   - asynchronous/synchronous: as a workaround for large repositories
+   - marking unchanged file: also workaround but also a user's choice (e.g.,
+                             marking unchanged or ignored files)
+   - discovering git repositories and showing their statuses
  * Reuse old cache for entire subtree while it's being updated (only a specific
    path gets to reuse it right now).
  * Make cache update faster if directory modification is detected.

--- a/data/plugins/git/README.md
+++ b/data/plugins/git/README.md
@@ -98,6 +98,8 @@ similar to how `git status --short` does it.
 
 **TODO:**
 
+ * Address obtaining GG entries failing for large repositories due to filling
+   of the pipe before `onexit` callback in invoked.
  * Reuse old cache for entire subtree while it's being updated (only a specific
    path gets to reuse it right now).
  * Make cache update faster if directory modification is detected.

--- a/data/plugins/git/README.md
+++ b/data/plugins/git/README.md
@@ -98,6 +98,8 @@ similar to how `git status --short` does it.
 
 **TODO:**
 
+ * Reuse old cache for entire subtree while it's being updated (only a specific
+   path gets to reuse it right now).
  * Make cache update faster if directory modification is detected.
  * Check if `!!` status can ever be seen.
  * Consider using `git status --porcelain=v2 -z` as it provides more

--- a/data/plugins/git/init.lua
+++ b/data/plugins/git/init.lua
@@ -70,7 +70,7 @@ local function status_column(info)
     local e = info.entry
 
     local node = statuses.get(e.location)
-    if not node.in_git then
+    if not node.in_git and not node.has_repos then
         return { text = '' }
     end
 

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -26,10 +26,6 @@ local function find_node(path)
         current = next
     end
 
-    if os.time() > current.expires then
-        return nil
-    end
-
     return current
 end
 
@@ -160,6 +156,18 @@ function is_dir(path)
     return false
 end
 
+local function shallow(tbl)
+    if tbl == nil then
+        return nil
+    end
+
+    local copy = { }
+    for k, v in pairs(tbl) do
+        copy[k] = v
+    end
+    return copy
+end
+
 local function fill_node(info)
     local node = info.node
     node.pending = (node.pending or 0) + 1
@@ -172,6 +180,8 @@ local function fill_node(info)
 
             node.pending = node.pending - 1
             if node.pending == 0 then
+                -- Can drop the cache now.
+                node.past = nil
                 redraw()
             end
         end
@@ -186,7 +196,12 @@ function M.get(at)
 
     local cached = find_node(at)
     if cached ~= nil then
-        return cached
+        if cached.expires >= os.time() then
+            -- Return old cached data while new one is being retrieved to avoid
+            -- flickering.
+            -- XXX: this doesn't apply to nested paths.
+            return cached.past or cached
+        end
     end
 
     local ts = os.time()
@@ -200,6 +215,9 @@ function M.get(at)
         update_subdirs(at, node)
         return node
     end
+
+    -- Make a copy before invoking init_node() on the same node.
+    cached = shallow(cached)
 
     local expires = ts + GIT_DIR_TTL
     local node = init_node(make_node(cache, at), expires)
@@ -221,6 +239,7 @@ function M.get(at)
         end
     end
 
+    node.past = cached
     fill_node {
         node = node,
         cmd = string.format('git -C %s status -z .', vifm.escape(at)),
@@ -249,7 +268,7 @@ function M.get(at)
         end
     }
 
-    return node
+    return node.past or node
 end
 
 return M

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -132,7 +132,7 @@ end
 
 --- Check the status of git repository subdirectories
 function update_subdirs(at, node)
-    local cmd = string.format('find %s -mindepth 2 -maxdepth 2 -type d -name .git -print0',
+    local cmd = string.format('find %s -mindepth 2 -maxdepth 2 \\( -type d -o -type f \\) -name .git -print0',
                               vifm.escape(at))
     vifm.startjob {
         cmd = cmd,

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -222,6 +222,17 @@ function M.get(at)
         end
     }
 
+    vifm.startjob {
+        cmd = string.format('git -C %s ls-tree HEAD -r --name-only -z .', vifm.escape(at)),
+        onexit = function(job)
+            local status_all = job:stdout():read('a')
+            for rel_path in string.gmatch(status_all, '[^\0]+') do
+                set_file_status(node, rel_path, 'GG', expires)
+            end
+            redraw()
+        end
+    }
+
     return node
 end
 

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -160,6 +160,24 @@ function is_dir(path)
     return false
 end
 
+local function fill_node(info)
+    local node = info.node
+    node.pending = (node.pending or 0) + 1
+
+    vifm.startjob {
+        cmd = info.cmd,
+        onexit = function(job)
+            local output = job:stdout():read('a')
+            info.callback(output)
+
+            node.pending = node.pending - 1
+            if node.pending == 0 then
+                redraw()
+            end
+        end
+    }
+end
+
 function M.get(at)
     at = vifm.fnamemodify(at, ':p')
     if vifm.fnamemodify(at, ':t') == '.' then
@@ -203,10 +221,10 @@ function M.get(at)
         end
     end
 
-    vifm.startjob {
+    fill_node {
+        node = node,
         cmd = string.format('git -C %s status -z .', vifm.escape(at)),
-        onexit = function(job)
-            local status_all = job:stdout():read('a')
+        callback = function(status_all)
             for entry in string.gmatch(status_all, '[^\0]+') do
                 local status = entry:sub(1, 2)
                 local abs_path = root..'/'..entry:sub(4)
@@ -218,18 +236,16 @@ function M.get(at)
                     set_file_status(node, rel_path, status, expires)
                 end
             end
-            redraw()
         end
     }
 
-    vifm.startjob {
+    fill_node {
+        node = node,
         cmd = string.format('git -C %s ls-tree HEAD -r --name-only -z .', vifm.escape(at)),
-        onexit = function(job)
-            local status_all = job:stdout():read('a')
+        callback = function(status_all)
             for rel_path in string.gmatch(status_all, '[^\0]+') do
                 set_file_status(node, rel_path, 'GG', expires)
             end
-            redraw()
         end
     }
 

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -132,13 +132,14 @@ end
 
 --- Check the status of git repository subdirectories
 function update_subdirs(at, node)
-    local cmd = string.format('find %s -mindepth 2 -maxdepth 2 -type d -name .git', vifm.escape(at))
+    local cmd = string.format('find %s -mindepth 2 -maxdepth 2 -type d -name .git -print0',
+                              vifm.escape(at))
     vifm.startjob {
         cmd = cmd,
         onexit = function(job)
             local status_all = job:stdout():read('a')
             node.has_repos = status_all ~= ''
-            for entry in string.gmatch(status_all, '[^\n]+') do
+            for entry in string.gmatch(status_all, '[^\0]+') do
                 local sub_at = vifm.fnamemodify(entry, ':h')
                 local sub_root = vifm.fnamemodify(entry, ':h:t')
                 update_subdir(sub_at, sub_root, node)

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -252,7 +252,8 @@ function M.get(at)
                 local abs_path = root..'/'..entry:sub(4)
                 local rel_path = abs_path:sub(1 + #at + 1)
                 if is_dir(abs_path..'/.git') then
-                    -- Strip the end of `rel_path`, to say the contents of the sub-repo isn't cached                                                                 │    │
+                    -- Strip the end of `rel_path`, to say the contents of the
+                    -- sub-repo isn't cached.
                     update_subdir(abs_path, rel_path:sub(1, -2), node)
                 else
                     set_file_status(node, rel_path, status, expires)

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -224,19 +224,22 @@ function M.get(at)
     node.in_git = true
 
     local subdirs = exec(string.format('git -C %s ls-tree -r -d --name-only -z HEAD .', vifm.escape(at)))
+    local subtree_has_changes = false
     for subdir in string.gmatch(subdirs, '[^\0]+') do
-        if subdir == '../' then
-            node.status = ''
-            -- no need to call `git status`
-            return node
-        end
+        if subdir ~= './' and subdir ~= '../' then
+            subtree_has_changes = true
 
-        if subdir ~= './' then
             local dir = make_node(node, subdir)
             dir.expires = expires
             dir.in_git = true
             dir.status = '  '
         end
+    end
+
+    if not subtree_has_changes then
+        node.status = ''
+        -- no need to call `git status`
+        return node
     end
 
     node.past = cached

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -118,8 +118,8 @@ local function exec(cmd)
 end
 
 function redraw()
-    local view = vifm.currview()
-    view:cd(view.cwd)
+    vifm.opts.global.laststatus = not vifm.opts.global.laststatus
+    vifm.opts.global.laststatus = not vifm.opts.global.laststatus
 end
 
 function M.get(at)

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -6,11 +6,12 @@ local GIT_DIR_TTL = 5
 local NON_GIT_DIR_TTL = 60
 
 local cache = {
-    in_git = false, -- whether current path is covered by Git
-    status = nil,   -- status derived from nested files
-    subs = { },     -- subdirectory name -> cache node
-    items = { },    -- file name -> status
-    expires = 0     -- when the cache entry expires
+    in_git = false,    -- whether current path is covered by Git
+    has_repos = false, -- whether current path is covered by Git
+    status = nil,      -- status derived from nested files
+    subs = { },        -- subdirectory name -> cache node
+    items = { },       -- file name         -> status
+    expires = 0        -- when the cache entry expires
 }
 
 local function find_node(path)
@@ -116,6 +117,11 @@ local function exec(cmd)
     return result, job:exitcode()
 end
 
+function redraw()
+    local view = vifm.currview()
+    view:cd(view.cwd)
+end
+
 function M.get(at)
     at = vifm.fnamemodify(at, ':p')
     if vifm.fnamemodify(at, ':t') == '.' then
@@ -135,6 +141,30 @@ function M.get(at)
         local node = make_node(cache, at)
         node.expires = ts + NON_GIT_DIR_TTL
         node.in_git = false
+
+        -- Check the status of git repository subdirectories
+        local cmd = string.format('find %s -mindepth 2 -maxdepth 2 -type d -name .git', vifm.escape(at))
+        vifm.startjob {
+            cmd = cmd,
+            onexit = function(job)
+                local status_all = job:stdout():read('a')
+                node.has_repos = status_all ~= ''
+                for entry in string.gmatch(status_all, '[^\n]+') do
+                    local sub_at = vifm.fnamemodify(entry, ':h')
+                    local sub_root = vifm.fnamemodify(entry, ':h:t')
+                    vifm.startjob {
+                        cmd = string.format('git -C %s status -z .', vifm.escape(sub_at)),
+                        onexit = function(sub_job)
+                            local sub_status_all = sub_job:stdout():read('a')
+                            local status = sub_status_all == '' and 'GG' or sub_status_all:sub(1, 2)
+                            set_file_status(node, sub_root, status, node.expires)
+                            redraw()
+                        end
+                    }
+                end
+            end
+        }
+
         return node
     end
 
@@ -168,9 +198,7 @@ function M.get(at)
                 local rel_path = abs_path:sub(1 + #at + 1)
                 set_file_status(node, rel_path, status, expires)
             end
-            -- redraw
-            local view = vifm.currview()
-            view:cd(view.cwd)
+            redraw()
         end
     }
 

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -158,13 +158,21 @@ function M.get(at)
         end
     end
 
-    local status = exec(string.format('git -C %s status -z .', vifm.escape(at)))
-    for entry in string.gmatch(status, '[^\0]+') do
-        local status = entry:sub(1, 2)
-        local abs_path = root..'/'..entry:sub(4)
-        local rel_path = abs_path:sub(1 + #at + 1)
-        set_file_status(node, rel_path, status, expires)
-    end
+    vifm.startjob {
+        cmd = string.format('git -C %s status -z .', vifm.escape(at)),
+        onexit = function(job)
+            local status_all = job:stdout():read('a')
+            for entry in string.gmatch(status_all, '[^\0]+') do
+                local status = entry:sub(1, 2)
+                local abs_path = root..'/'..entry:sub(4)
+                local rel_path = abs_path:sub(1 + #at + 1)
+                set_file_status(node, rel_path, status, expires)
+            end
+            -- redraw
+            local view = vifm.currview()
+            view:cd(view.cwd)
+        end
+    }
 
     return node
 end

--- a/data/plugins/git/statuses.lua
+++ b/data/plugins/git/statuses.lua
@@ -122,6 +122,44 @@ function redraw()
     vifm.opts.global.laststatus = not vifm.opts.global.laststatus
 end
 
+function update_subdir(sub_at, path, node)
+    vifm.startjob {
+        cmd = string.format('git -C %s status -z .', vifm.escape(sub_at)),
+        onexit = function(sub_job)
+            local sub_status_all = sub_job:stdout():read('a')
+            local status = sub_status_all == '' and 'GG' or sub_status_all:sub(1, 2)
+            set_file_status(node, path, status, node.expires)
+            redraw()
+        end
+    }
+end
+
+--- Check the status of git repository subdirectories
+function update_subdirs(at, node)
+    local cmd = string.format('find %s -mindepth 2 -maxdepth 2 -type d -name .git', vifm.escape(at))
+    vifm.startjob {
+        cmd = cmd,
+        onexit = function(job)
+            local status_all = job:stdout():read('a')
+            node.has_repos = status_all ~= ''
+            for entry in string.gmatch(status_all, '[^\n]+') do
+                local sub_at = vifm.fnamemodify(entry, ':h')
+                local sub_root = vifm.fnamemodify(entry, ':h:t')
+                update_subdir(sub_at, sub_root, node)
+            end
+        end
+    }
+end
+
+function is_dir(path)
+    local f = io.open(path .. "/")
+    if f then
+        f:close()
+        return true
+    end
+    return false
+end
+
 function M.get(at)
     at = vifm.fnamemodify(at, ':p')
     if vifm.fnamemodify(at, ':t') == '.' then
@@ -141,30 +179,7 @@ function M.get(at)
         local node = make_node(cache, at)
         node.expires = ts + NON_GIT_DIR_TTL
         node.in_git = false
-
-        -- Check the status of git repository subdirectories
-        local cmd = string.format('find %s -mindepth 2 -maxdepth 2 -type d -name .git', vifm.escape(at))
-        vifm.startjob {
-            cmd = cmd,
-            onexit = function(job)
-                local status_all = job:stdout():read('a')
-                node.has_repos = status_all ~= ''
-                for entry in string.gmatch(status_all, '[^\n]+') do
-                    local sub_at = vifm.fnamemodify(entry, ':h')
-                    local sub_root = vifm.fnamemodify(entry, ':h:t')
-                    vifm.startjob {
-                        cmd = string.format('git -C %s status -z .', vifm.escape(sub_at)),
-                        onexit = function(sub_job)
-                            local sub_status_all = sub_job:stdout():read('a')
-                            local status = sub_status_all == '' and 'GG' or sub_status_all:sub(1, 2)
-                            set_file_status(node, sub_root, status, node.expires)
-                            redraw()
-                        end
-                    }
-                end
-            end
-        }
-
+        update_subdirs(at, node)
         return node
     end
 
@@ -196,7 +211,12 @@ function M.get(at)
                 local status = entry:sub(1, 2)
                 local abs_path = root..'/'..entry:sub(4)
                 local rel_path = abs_path:sub(1 + #at + 1)
-                set_file_status(node, rel_path, status, expires)
+                if is_dir(abs_path..'/.git') then
+                    -- Strip the end of `rel_path`, to say the contents of the sub-repo isn't cached                                                                 │    │
+                    update_subdir(abs_path, rel_path:sub(1, -2), node)
+                else
+                    set_file_status(node, rel_path, status, expires)
+                end
             end
             redraw()
         end


### PR DESCRIPTION
I tried to do a todo. Hope this is what you're looking for.