### PR TITLE
Add 'keepsel' option for a more persistent selection

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -235,6 +235,8 @@
 	Fixed a Lua column disabling search highlighting for all columns to its
 	right.
 
+	Added 'keepsel' option to retain selection across mode switches.
+
 0.14-beta to 0.14 (2025-02-08)
 
 	Improved documentation on zh/zl menu keys a bit.

--- a/data/man/vifm.1
+++ b/data/man/vifm.1
@@ -4650,6 +4650,16 @@ When this option is set, search and view update for local filter is be
 performed starting from initial cursor position each time search pattern is
 changed.
 .TP
+.BI "'keepsel'"
+type: boolean
+.br
+default: false
+.br
+By default, vifm will reset the selection when switching from command-line mode
+to normal mode, even if no command was executed. Setting this option makes vifm
+retain the current selection when switching from command-line mode or menu mode
+to normal mode.
+.TP
 .BI 'iooptions'
 type: set
 .br

--- a/data/vim/doc/app/vifm-app.txt
+++ b/data/vim/doc/app/vifm-app.txt
@@ -3914,6 +3914,16 @@ When this option is set, search and view update for local filter is be
 performed starting from initial cursor position each time search pattern is
 changed.
 
+                                               *vifm-'keepsel'*
+keepsel
+type: boolean
+default: false
+
+By default, vifm will reset the selection when switching from command-line
+mode to normal mode, even if no command was executed. Setting this option
+makes vifm retain the current selection when switching from command-line mode
+or menu mode to normal mode.
+
                                                *vifm-'iooptions'*
 iooptions
 type: set

--- a/data/vim/syntax/vifm.vim
+++ b/data/vim/syntax/vifm.vim
@@ -1,6 +1,6 @@
 " vifm syntax file
 " Maintainer:  xaizek <xaizek@posteo.net>
-" Last Change: March 4, 2026
+" Last Change: Apr 30, 2026
 " Inspired By: Vim syntax file by Dr. Charles E. Campbell, Jr.
 
 if exists('b:current_syntax')
@@ -162,17 +162,17 @@ syntax keyword vifmOption contained aproposprg autocd autochpos caseoptions
 		\ cdpath cd chaselinks classify columns co confirm cf cpoptions cpo
 		\ cvoptions deleteprg dotdirs dotfiles dirsize extprompt fastrun fillchars
 		\ fcs findprg followlinks fusehome gdefault grepprg histcursor history hi
-		\ hloptions hlsearch hls iec ignorecase ic iooptions incsearch is laststatus
-		\ lines locateprg ls lsoptions lsview mediaprg milleroptions millerview
-		\ mintimeoutlen mouse navoptions number nu numberwidth nuw previewoptions
-		\ previewprg quickview relativenumber rnu rulerformat ruf runexec scrollbind
-		\ scb scrolloff sessionoptions ssop so sort sortgroups sortorder sortnumbers
-		\ shell sh shellflagcmd shcf shortmess shm showtabline stal sizefmt slowfs
-		\ smartcase scs statusline stl suggestoptions syncregs syscalls tablabel
-		\ tabline tabprefix tabscope tabstop tabsuffix tal timefmt timeoutlen title
-		\ tm trash trashdir ts tuioptions to uioptions undolevels ul vicmd
-		\ viewcolumns vifminfo vimhelp vixcmd wildinc wildmenu wmnu wildstyle
-		\ wordchars wrap wrapscan ws
+		\ hloptions hlsearch hls iec ignorecase ic iooptions incsearch is keepsel
+		\ laststatus lines locateprg ls lsoptions lsview mediaprg milleroptions
+		\ millerview mintimeoutlen mouse navoptions number nu numberwidth nuw
+		\ previewoptions previewprg quickview relativenumber rnu rulerformat ruf
+		\ runexec scrollbind scb scrolloff sessionoptions ssop so sort sortgroups
+		\ sortorder sortnumbers shell sh shellflagcmd shcf shortmess shm showtabline
+		\ stal sizefmt slowfs smartcase scs statusline stl suggestoptions syncregs
+		\ syscalls tablabel tabline tabprefix tabscope tabstop tabsuffix tal timefmt
+		\ timeoutlen title tm trash trashdir ts tuioptions to uioptions undolevels
+		\ ul vicmd viewcolumns vifminfo vimhelp vixcmd wildinc wildmenu wmnu
+		\ wildstyle wordchars wrap wrapscan ws
 
 " Disabled boolean options
 syntax keyword vifmOption contained noautocd noautochpos nocf nochaselinks

--- a/src/cfg/config.c
+++ b/src/cfg/config.c
@@ -196,6 +196,7 @@ cfg_init(void)
 	cfg.use_unicode_characters = 0;
 	cfg.color_what = CW_ONE_ROW;
 	cfg.flexible_splitter = 1;
+	cfg.keepsel = 0;
 	cfg.display_statusline = 1;
 
 	cfg.vborder_filler = strdup(" ");

--- a/src/cfg/config.h
+++ b/src/cfg/config.h
@@ -336,6 +336,9 @@ typedef struct config_t
 	 * sizes. */
 	int flexible_splitter;
 
+	/* persist selection across mode switches */
+	int keepsel;
+
 	/* Whether displaying status line is enabled. */
 	int display_statusline;
 

--- a/src/cfg/info.c
+++ b/src/cfg/info.c
@@ -2276,6 +2276,7 @@ store_global_options(JSON_Object *root)
 				cfg.sizefmt.ieci_prefixes ? "" : "no"));
 	append_dstr(options, format_str("%signorecase", cfg.ignore_case ? "" : "no"));
 	append_dstr(options, format_str("%sincsearch", cfg.inc_search ? "" : "no"));
+	append_dstr(options, format_str("%skeepsel", cfg.keepsel ? "" : "no"));
 	append_dstr(options, format_str("%slaststatus",
 				cfg.display_statusline ? "" : "no"));
 	append_dstr(options, format_str("%stitle", cfg.set_title ? "" : "no"));

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -511,7 +511,10 @@ cmds_exec(const char cmd[], view_t *view, int menu, int keep_sel)
 
 	if(cmd == NULL)
 	{
-		flist_sel_stash_if_nonempty(view);
+		if(!keep_sel)
+		{
+			flist_sel_stash_if_nonempty(view);
+		}
 		return 0;
 	}
 
@@ -522,7 +525,10 @@ cmds_exec(const char cmd[], view_t *view, int menu, int keep_sel)
 
 	if(cmd[0] == '\0' && !menu)
 	{
-		flist_sel_stash_if_nonempty(view);
+		if(!keep_sel)
+		{
+			flist_sel_stash_if_nonempty(view);
+		}
 		return 0;
 	}
 
@@ -620,7 +626,10 @@ cmds_exec(const char cmd[], view_t *view, int menu, int keep_sel)
 
 	if(!menu && vle_mode_is(NORMAL_MODE))
 	{
-		flist_sel_stash_if_nonempty(view);
+		if(!keep_sel)
+		{
+			flist_sel_stash_if_nonempty(view);
+		}
 	}
 
 	return -1;
@@ -1185,7 +1194,7 @@ cmds_dispatch1(const char cmd[], view_t *view, CmdInputType type)
 
 		case CIT_MENU_COMMAND: menu = 1; /* Fall through. */
 		case CIT_COMMAND:
-			return cmds_exec(cmd, view, menu, /*keep_sel=*/0);
+			return cmds_exec(cmd, view, menu, /*keep_sel=*/cfg.keepsel);
 
 		case CIT_FILTER_PATTERN:
 			if(view->custom.type != CV_DIFF)
@@ -1229,7 +1238,8 @@ repeat_command(view_t *view, CmdInputType type)
 			return modview_find(NULL, backward);
 
 		case CIT_COMMAND:
-			return cmds_exec(/*cmd=*/NULL, view, /*menu=*/0, /*keep_sel=*/0);
+			return cmds_exec(/*cmd=*/NULL, view, /*menu=*/0,
+					/*keep_sel=*/cfg.keepsel);
 
 		case CIT_FILTER_PATTERN:
 			local_filter_apply(view, "");

--- a/src/cmd_handlers.c
+++ b/src/cmd_handlers.c
@@ -1081,7 +1081,10 @@ emark_cmd(const cmd_info_t *cmd_info)
 		const int use_term_mux = ma_flags_missing(flags, MF_NO_TERM_MUX);
 		const ShellPause pause = (cmd_info->emark ? PAUSE_ALWAYS : PAUSE_ON_ERROR);
 
-		flist_sel_stash(curr_view);
+		if(!cfg.keepsel)
+		{
+			flist_sel_stash(curr_view);
+		}
 
 		const char *cmd_to_run = com;
 		char *expanded_cmd = NULL;
@@ -5991,7 +5994,10 @@ usercmd_cmd(const cmd_info_t *cmd_info)
 		ext_cmd = skip_whitespace(ext_cmd);
 	}
 
-	flist_sel_stash(curr_view);
+	if (!cfg.keepsel)
+	{
+		flist_sel_stash(curr_view);
+	}
 
 	char *title = format_str(":%s%s%s", cmd_info->user_cmd,
 			(cmd_info->raw_args[0] == '\0' ? "" : " "), cmd_info->raw_args);

--- a/src/modes/cmdline.c
+++ b/src/modes/cmdline.c
@@ -1719,7 +1719,7 @@ cmd_return(key_info_t key_info, keys_info_t *keys_info)
 	if(prev_mode == VISUAL_MODE && sub_mode != CLS_VFSEARCH &&
 			sub_mode != CLS_VBSEARCH)
 	{
-		modvis_leave(curr_stats.save_msg, !cfg.keepsel, !cfg.keepsel);
+		modvis_leave(curr_stats.save_msg, !cfg.keepsel, 0);
 	}
 
 	if(sub_mode == CLS_COMMAND || sub_mode == CLS_MENU_COMMAND)

--- a/src/modes/cmdline.c
+++ b/src/modes/cmdline.c
@@ -1142,13 +1142,9 @@ cmd_ctrl_c(key_info_t key_info, keys_info_t *keys_info)
 	const line_stats_t old_input_stat = input_stat;
 	leave_cmdline_mode(/*cancelled=*/1);
 
-	if(old_input_stat.prev_mode == VISUAL_MODE)
+	if(old_input_stat.prev_mode == VISUAL_MODE && !old_input_stat.search_mode)
 	{
-		if(!old_input_stat.search_mode)
-		{
-			modvis_leave(curr_stats.save_msg, 1, 1);
-			fpos_set_pos(curr_view, marks_find_in_view(curr_view, '<'));
-		}
+		modvis_leave(curr_stats.save_msg, !cfg.keepsel, !cfg.keepsel);
 	}
 
 	if(old_input_stat.sub_mode == CLS_COMMAND)
@@ -1723,7 +1719,7 @@ cmd_return(key_info_t key_info, keys_info_t *keys_info)
 	if(prev_mode == VISUAL_MODE && sub_mode != CLS_VFSEARCH &&
 			sub_mode != CLS_VBSEARCH)
 	{
-		modvis_leave(curr_stats.save_msg, 1, 0);
+		modvis_leave(curr_stats.save_msg, !cfg.keepsel, !cfg.keepsel);
 	}
 
 	if(sub_mode == CLS_COMMAND || sub_mode == CLS_MENU_COMMAND)

--- a/src/modes/dialogs/attr_dialog_nix.c
+++ b/src/modes/dialogs/attr_dialog_nix.c
@@ -31,6 +31,7 @@
 #include <stdio.h> /* snprintf() */
 #include <string.h> /* strncat() strlen() */
 
+#include "../../cfg/config.h"
 #include "../../compat/curses.h"
 #include "../../compat/fs_limits.h"
 #include "../../engine/keys.h"
@@ -59,7 +60,7 @@ static char * get_title(int max_width);
 static int is_one_file_selected(int first_file_index);
 static int get_first_file_index(void);
 static int get_selection_size(int first_file_index);
-static void leave_attr_mode(void);
+static void leave_attr_mode(int reset_selection);
 static void cmd_ctrl_c(key_info_t key_info, keys_info_t *keys_info);
 static void cmd_return(key_info_t key_info, keys_info_t *keys_info);
 TSTATIC void set_perm_string(view_t *view, const int perms[13],
@@ -221,7 +222,7 @@ enter_attr_mode(view_t *active_view)
 	{
 		show_error_msg("Permissions change error",
 				"Selected files have no common access state");
-		leave_attr_mode();
+		leave_attr_mode(1);
 		return;
 	}
 
@@ -368,20 +369,23 @@ get_selection_size(int first_file_index)
 }
 
 static void
-leave_attr_mode(void)
+leave_attr_mode(int reset_selection)
 {
 	vle_mode_set(NORMAL_MODE, VMT_PRIMARY);
 	ui_set_cursor(/*visibility=*/0);
 	curr_stats.use_input_bar = 1;
 
-	flist_sel_stash(view);
+	if(reset_selection)
+	{
+		flist_sel_stash(view);
+	}
 	ui_view_schedule_reload(view);
 }
 
 static void
 cmd_ctrl_c(key_info_t key_info, keys_info_t *keys_info)
 {
-	leave_attr_mode();
+	leave_attr_mode(!cfg.keepsel);
 }
 
 static void
@@ -397,7 +401,7 @@ cmd_return(key_info_t key_info, keys_info_t *keys_info)
 	get_current_full_path(view, sizeof(path), path);
 	set_perm_string(view, perms, origin_perms, adv_perms);
 
-	leave_attr_mode();
+	leave_attr_mode(1);
 }
 
 TSTATIC void

--- a/src/modes/menu.c
+++ b/src/modes/menu.c
@@ -331,7 +331,7 @@ key_handler(wchar_t key)
 	if(pass_combination_to_khandler(shortcut) && menu->len == 0)
 	{
 		show_error_msg("No more items in the menu", "Menu will be closed");
-		leave_menu_mode(1);
+		leave_menu_mode(!cfg.keepsel);
 	}
 
 	return 0;
@@ -369,7 +369,7 @@ modmenu_reenter(view_t *target_view)
 void
 modmenu_abort(void)
 {
-	leave_menu_mode(1);
+	leave_menu_mode(!cfg.keepsel);
 }
 
 void
@@ -425,7 +425,7 @@ can_scroll_menu_up(const menu_data_t *menu)
 static void
 cmd_ctrl_c(key_info_t key_info, keys_info_t *keys_info)
 {
-	leave_menu_mode(1);
+	leave_menu_mode(!cfg.keepsel);
 }
 
 static void
@@ -759,7 +759,7 @@ cmd_dd(key_info_t key_info, keys_info_t *keys_info)
 	if(pass_combination_to_khandler(L"dd") && menu->len == 0)
 	{
 		show_error_msg("Menu is closing", "No more items in the menu");
-		leave_menu_mode(1);
+		leave_menu_mode(!cfg.keepsel);
 	}
 }
 
@@ -790,7 +790,7 @@ pass_combination_to_khandler(const wchar_t keys[])
 			ui_refresh_win(menu_win);
 			return 1;
 		case KHR_CLOSE_MENU:
-			leave_menu_mode(1);
+			leave_menu_mode(!cfg.keepsel);
 			return 1;
 		case KHR_MORPHED_MENU:
 			assert(!vle_mode_is(MENU_MODE) && "Wrong use of KHR_MORPHED_MENU.");
@@ -1087,7 +1087,7 @@ nohlsearch_cmd(const cmd_info_t *cmd_info)
 static int
 quit_cmd(const cmd_info_t *cmd_info)
 {
-	leave_menu_mode(1);
+	leave_menu_mode(!cfg.keepsel);
 	return 0;
 }
 

--- a/src/opt_handlers.c
+++ b/src/opt_handlers.c
@@ -150,6 +150,7 @@ static void iec_handler(OPT_OP op, optval_t val);
 static void ignorecase_handler(OPT_OP op, optval_t val);
 static void incsearch_handler(OPT_OP op, optval_t val);
 static void iooptions_handler(OPT_OP op, optval_t val);
+static void keepsel_handler(OPT_OP op, optval_t val);
 static void laststatus_handler(OPT_OP op, optval_t val);
 static void lines_handler(OPT_OP op, optval_t val);
 static void locateprg_handler(OPT_OP op, optval_t val);
@@ -725,6 +726,10 @@ options[] = {
 	  OPT_SET, ARRAY_LEN(iooptions_vals), iooptions_vals, &iooptions_handler,
 	  NULL,
 	  { .init = &init_iooptions },
+	},
+	{ "keepsel", "", "preserve selection when switching to normal mode",
+		OPT_BOOL, 0, NULL, &keepsel_handler, NULL,
+		{ .ref.bool_val = &cfg.keepsel }
 	},
 	{ "laststatus", "ls", "visibility of status bar",
 	  OPT_BOOL, 0, NULL, &laststatus_handler, NULL,
@@ -2407,6 +2412,12 @@ iooptions_handler(OPT_OP op, optval_t val)
 {
 	cfg.fast_file_cloning = ((val.set_items & 1) != 0);
 	cfg.data_sync = ((val.set_items & 2) != 0);
+}
+
+static void
+keepsel_handler(OPT_OP op, optval_t val)
+{
+	cfg.keepsel = val.bool_val;
 }
 
 static void

--- a/src/tags.c
+++ b/src/tags.c
@@ -81,6 +81,7 @@ const char *tags[] = {
 	"vifm-'incsearch'",
 	"vifm-'iooptions'",
 	"vifm-'is'",
+	"vifm-'keepsel'",
 	"vifm-'laststatus'",
 	"vifm-'lines'",
 	"vifm-'locateprg'",


### PR DESCRIPTION
vifm often inconveniently resets the selection, for example after cancelling command-line entry. I understand that this is made to mimic how vim behaves, but I find it to be unhelpful in a file manager.  

This pull request adds an option `'keepsel'`, that when set makes it so vifm behaves a little more intuitively, and closer to how other terminal file managers do (ranger, lf, mc). It is disabled by default.

Thank you.