### PR TITLE
Windows: fix sixel/pass-through preview via CONOUT$ and VT mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -201,3 +201,5 @@ plugin.
 cairo55 implemented 'keepsel' option.
 
 Vladimir Baranov exposed `os.remove()` in Lua.
+
+Maxim4711 provided a patch to make dispalaying Sixel on Windows Terminal work.

--- a/BUGS
+++ b/BUGS
@@ -24,3 +24,4 @@
   non-POSIX shells which have `-c` option accept a value.
 * Incrementing/decrementing file names doesn't work as expected for numbers
   outside [-2**63; -2**63) range.
+* Sixel doesn't get cleared in Windows Terminal on moving panes around.

--- a/ChangeLog
+++ b/ChangeLog
@@ -58,6 +58,10 @@
 	expression but is used to specify patterns like `{*.pdf}!/abc/` after the
 	plus sign.  Thanks to filterfalse, tagwint and CaptainFantastic.
 
+	Added somewhat incomplete handling of Sixel for Windows Terminal.
+	Clearing doesn't happen if moving panes while Sixel is displayed, but it
+	works otherwise.  Patch by Maxim4711.
+
 	Updated utf8proc to v2.11.3.
 
 	Made documentation on which :commands can have comments a bit more

--- a/src/ui/quickview.c
+++ b/src/ui/quickview.c
@@ -205,7 +205,17 @@ qv_draw(view_t *view)
 		return;
 	}
 
+	/* Clear any sixel graphics from the previous frame before erasing the
+	 * window and drawing new content.  PDCurses character cells alone do not
+	 * cover sixel pixels in Windows Terminal. */
+	if(other_view->displays_graphics)
+	{
+		ui_pass_through_clear(other_view->win);
+	}
+
 	ui_view_erase(other_view, 1);
+
+	other_view->displays_graphics = 0;
 
 	curr = get_current_entry(view);
 	if(!fentry_is_fake(curr))
@@ -220,6 +230,7 @@ qv_draw(view_t *view)
 			.h = ui_qv_height(other_view),
 		};
 		(void)view_entry(curr, &parea, &qv_cache);
+		other_view->displays_graphics = (qv_cache.kind != VK_TEXTUAL);
 	}
 
 	refresh_view_win(other_view);
@@ -358,6 +369,7 @@ view_file(const char path[], const preview_area_t *parea,
 
 	update_cache(cache, path, viewer, kind, parea, max_lines);
 	strlist_t lines = get_lines(cache);
+
 	draw_lines(&lines, cfg.wrap_quick_view, &cache->pa, cache->kind);
 
 	if(cache->kind != VK_TEXTUAL)
@@ -365,6 +377,14 @@ view_file(const char path[], const preview_area_t *parea,
 		free_string_array(cache->lines.items, cache->lines.nitems);
 		cache->lines.items = copy_string_array(lines.items, lines.nitems);
 		cache->lines.nitems = lines.nitems;
+
+		/* Pass-through output arrives asynchronously.  If no lines are available
+		 * yet, mark the cache stale so the next redraw re-fetches from vcache
+		 * instead of re-using empty cached lines. */
+		if(cache->kind == VK_PASS_THROUGH && lines.nitems == 0)
+		{
+			cache->graphics_lost = 1;
+		}
 	}
 
 	return clear_cmd;
@@ -436,8 +456,12 @@ get_lines(const quickview_cache_t *cache)
 	               ? NULL
 	               : qv_expand_viewer(cache->pa.source, cache->viewer, &flags);
 
+	/* Pass-through viewers (sixel etc.) must complete before we call puts() to
+	 * replay their output.  Force synchronous mode so the first render has
+	 * content rather than requiring an async redraw cycle. */
+	const int sync_mode = (cache->kind == VK_PASS_THROUGH) ? VC_SYNC : VC_ASYNC;
 	strlist_t lines = vcache_lookup(cache->path, expanded, flags, cache->kind,
-			cache->max_lines, VC_ASYNC, &error);
+			cache->max_lines, sync_mode, &error);
 	free(expanded);
 
 	if(error != NULL)
@@ -938,6 +962,11 @@ qv_cleanup_area(const preview_area_t *parea, const char cmd[])
 static void
 wipe_area(const preview_area_t *parea)
 {
+	if(curr_stats.preview.kind != VK_TEXTUAL)
+	{
+		ui_pass_through_clear(parea->view->win);
+	}
+
 	if(cfg.hard_graphics_clear)
 	{
 		wclear(parea->view->win);

--- a/src/ui/quickview.c
+++ b/src/ui/quickview.c
@@ -937,6 +937,11 @@ qv_cleanup_area(const preview_area_t *parea, const char cmd[])
 static void
 wipe_area(const preview_area_t *parea)
 {
+	if(curr_stats.preview.kind == VK_PASS_THROUGH)
+	{
+		ui_pass_through_clear(parea);
+	}
+
 	if(cfg.hard_graphics_clear)
 	{
 		wclear(parea->view->win);

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -1613,6 +1613,27 @@ refresh_view_win(view_t *view)
 		return;
 	}
 
+	/* Skip refreshing the preview pane's window when it's displaying
+	 * pass-through graphics (e.g. sixel).  wrefresh() would overwrite graphics
+	 * written directly to the terminal in ui_pass_through().  On PDCurses,
+	 * wrefresh() rewrites all character cells unconditionally via the Windows
+	 * Console API, erasing sixel pixels; on ncurses this call is a no-op when
+	 * the window is unchanged, so the guard is harmless on Linux too. */
+	if(curr_stats.preview.on && view == other_view && view->displays_graphics)
+	{
+		refresh_bottom_lines();
+		return;
+	}
+
+	/* When preview mode is off but the preview pane still has sixel graphics,
+	 * erase them before PDCurses redraws the main pane over that area.
+	 * Without this, sixel pixels show through the newly-drawn character cells. */
+	if(!curr_stats.preview.on && other_view->displays_graphics)
+	{
+		ui_pass_through_clear(other_view->win);
+		other_view->displays_graphics = 0;
+	}
+
 	ui_refresh_win(view->win);
 	refresh_bottom_lines();
 }
@@ -3054,6 +3075,50 @@ ui_drop_attr(WINDOW *win)
 }
 
 void
+ui_pass_through_clear(WINDOW *win)
+{
+#ifdef _WIN32
+	HANDLE hout = CreateFileA("\\\\.\\CONOUT$",
+			GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE,
+			NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	if(hout == INVALID_HANDLE_VALUE)
+		return;
+
+	DWORD mode_orig = 0;
+	GetConsoleMode(hout, &mode_orig);
+	SetConsoleMode(hout, mode_orig
+			| ENABLE_PROCESSED_OUTPUT
+			| ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+	const int width = getmaxx(win);
+	const int height = getmaxy(win);
+	const int begy = getbegy(win);
+	const int begx = getbegx(win);
+
+	char *blanks = malloc(width);
+	if(blanks != NULL)
+	{
+		memset(blanks, ' ', width);
+		int row;
+		for(row = 0; row < height; ++row)
+		{
+			COORD pos = {(SHORT)begx, (SHORT)(begy + row)};
+			SetConsoleCursorPosition(hout, pos);
+			DWORD written;
+			/* SGR 0 resets colors to default (opaque), covering sixel pixels. */
+			WriteFile(hout, "\x1b[0m", 4, &written, NULL);
+			WriteFile(hout, blanks, (DWORD)width, &written, NULL);
+		}
+		free(blanks);
+	}
+
+	SetConsoleMode(hout, mode_orig);
+	CloseHandle(hout);
+#endif
+	(void)win;
+}
+
+void
 ui_pass_through(const strlist_t *lines, WINDOW *win, int x, int y)
 {
 	/* Position hardware cursor on the screen. */
@@ -3061,10 +3126,52 @@ ui_pass_through(const strlist_t *lines, WINDOW *win, int x, int y)
 	use_wrefresh(win);
 
 	int i;
+#ifdef _WIN32
+	/* On Windows, PDCurses calls SetConsoleActiveScreenBuffer() during
+	 * initscr(), so GetStdHandle(STD_OUTPUT_HANDLE) returns the old inactive
+	 * buffer — writing there is invisible.  Open CONOUT$ to get the currently
+	 * active screen buffer (whichever one PDCurses is rendering into). */
+	{
+		HANDLE hout = CreateFileA("\\\\.\\CONOUT$",
+				GENERIC_READ | GENERIC_WRITE, FILE_SHARE_WRITE,
+				NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+		if(hout != INVALID_HANDLE_VALUE)
+		{
+			/* PDCurses sets output mode to ENABLE_LVB_GRID_WORLDWIDE (0x10)
+			 * only — it strips ENABLE_PROCESSED_OUTPUT so that ESC bytes are
+			 * not interpreted as control characters.  Without PROCESSED_OUTPUT,
+			 * ENABLE_VIRTUAL_TERMINAL_PROCESSING has no effect (ESC is never
+			 * recognized as a sequence start).  Set both, write, then restore
+			 * the original mode so PDCurses' next redraw is unaffected. */
+			DWORD mode_orig = 0;
+			GetConsoleMode(hout, &mode_orig);
+			SetConsoleMode(hout, mode_orig
+					| ENABLE_PROCESSED_OUTPUT
+					| ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+
+			COORD pos = {(SHORT)(getbegx(win) + x), (SHORT)(getbegy(win) + y)};
+
+			for(i = 0; i < lines->nitems; ++i)
+			{
+				COORD line_pos = {pos.X, (SHORT)(pos.Y + i)};
+				SetConsoleCursorPosition(hout, line_pos);
+				const char *line = lines->items[i];
+				DWORD written;
+				WriteFile(hout, line, (DWORD)strlen(line), &written, NULL);
+			}
+
+			/* Restore PDCurses' original console mode. */
+			SetConsoleMode(hout, mode_orig);
+			CloseHandle(hout);
+		}
+	}
+#else
 	for(i = 0; i < lines->nitems; ++i)
 	{
 		puts(lines->items[i]);
 	}
+	fflush(stdout);
+#endif
 
 	/* Make curses synchronize its idea about where cursor is with the terminal
 	 * state. */

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -3063,18 +3063,82 @@ ui_drop_attr(WINDOW *win)
 }
 
 void
+ui_pass_through_clear(const preview_area_t *parea)
+{
+#ifdef _WIN32
+	HANDLE hout = win_conout();
+	if(hout == INVALID_HANDLE_VALUE)
+	{
+		return;
+	}
+
+	DWORD orig_mode = win_vterm_start(hout);
+
+	const int width = parea->w;
+	const int height = parea->h;
+	const int begy = getbegy(parea->view->win) + parea->y;
+	const int begx = getbegx(parea->view->win) + parea->x;
+
+	char *blanks = malloc(width);
+	if(blanks != NULL)
+	{
+		memset(blanks, ' ', width);
+
+		int row;
+		for(row = 0; row < height; ++row)
+		{
+			COORD pos = { begx, begy + row };
+			SetConsoleCursorPosition(hout, pos);
+
+			/* SGR 0 resets colors to default (opaque), covering sixel pixels. */
+			DWORD written;
+			WriteFile(hout, "\x1b[0m", 4, &written, NULL);
+			WriteFile(hout, blanks, width, &written, NULL);
+		}
+
+		free(blanks);
+	}
+
+	win_vterm_finish(hout, orig_mode);
+#endif
+}
+
+void
 ui_pass_through(const strlist_t *lines, WINDOW *win, int x, int y)
 {
 	/* Position hardware cursor on the screen. */
 	checked_wmove(win, y, x);
 	use_wrefresh(win);
 
+#ifdef _WIN32
+	HANDLE hout = win_conout();
+	if(hout != INVALID_HANDLE_VALUE)
+	{
+		DWORD orig_mode = win_vterm_start(hout);
+
+		COORD pos = { getbegx(win) + x, getbegy(win) + y };
+
+		int i;
+		for(i = 0; i < lines->nitems; ++i)
+		{
+			COORD line_pos = { pos.X, pos.Y + i };
+			SetConsoleCursorPosition(hout, line_pos);
+
+			DWORD written;
+			const char *line = lines->items[i];
+			WriteFile(hout, line, strlen(line), &written, NULL);
+		}
+
+		win_vterm_finish(hout, orig_mode);
+	}
+#else
 	int i;
 	for(i = 0; i < lines->nitems; ++i)
 	{
 		puts(lines->items[i]);
 	}
 	fflush(stdout);
+#endif
 
 	/* Make curses synchronize its idea about where cursor is with the terminal
 	 * state. */

--- a/src/ui/ui.c
+++ b/src/ui/ui.c
@@ -3074,6 +3074,7 @@ ui_pass_through(const strlist_t *lines, WINDOW *win, int x, int y)
 	{
 		puts(lines->items[i]);
 	}
+	fflush(stdout);
 
 	/* Make curses synchronize its idea about where cursor is with the terminal
 	 * state. */

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -843,6 +843,11 @@ struct strlist_t;
  * specified point on the window beforehand. */
 void ui_pass_through(const struct strlist_t *lines, WINDOW *win, int x, int y);
 
+/* Erases pass-through graphics (e.g. sixel) from win by filling every cell
+ * with a space via the VT path so sixel pixels don't bleed through after the
+ * view switches back to text.  No-op on non-Windows builds. */
+void ui_pass_through_clear(WINDOW *win);
+
 /* Maps column name to column id.  Returns column id or -1 on error. */
 int ui_map_column_name(const char name[]);
 

--- a/src/ui/ui.h
+++ b/src/ui/ui.h
@@ -843,6 +843,13 @@ struct strlist_t;
  * specified point on the window beforehand. */
 void ui_pass_through(const struct strlist_t *lines, WINDOW *win, int x, int y);
 
+struct preview_area_t;
+
+/* Erases pass-through graphics (e.g., sixel) using a platform/terminal-specific
+ * way to avoid graphics bleeding through after drawing something on top of
+ * it. */
+void ui_pass_through_clear(const struct preview_area_t *parea);
+
 /* Maps column name to column id.  Returns column id or -1 on error. */
 int ui_map_column_name(const char name[]);
 

--- a/src/utils/utils_win.c
+++ b/src/utils/utils_win.c
@@ -57,6 +57,11 @@
 #include "test_helpers.h"
 #include "utf8.h"
 
+// This macro may not be available in some toolchains.
+#ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+#  define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#endif
+
 #define PE_HDR_SIGNATURE 0x00004550U
 #define PE_HDR_OFFSET 0x3cU
 #define PE_HDR_SUBSYSTEM_OFFSET 0x5cU
@@ -1371,6 +1376,77 @@ create_new_file(const char path[], mode_t mode, int auto_delete)
 	}
 
 	return fd;
+}
+
+HANDLE
+win_conout(void)
+{
+	/* The buffer (see below) shouldn't change, so there should be no need to
+	 * open it more than once. */
+	static HANDLE conout;
+
+	if(conout == NULL || conout == INVALID_HANDLE_VALUE)
+	{
+		/* On Windows, PDCurses calls SetConsoleActiveScreenBuffer() during
+		 * initscr(), so GetStdHandle(STD_OUTPUT_HANDLE) returns the old inactive
+		 * buffer and writing there is invisible.  Open CONOUT$ to get the currently
+		 * active screen buffer (whichever one PDCurses is rendering into). */
+		conout = CreateFileW(L"CONOUT$", GENERIC_READ | GENERIC_WRITE,
+				FILE_SHARE_WRITE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
+	}
+
+	return conout;
+}
+
+DWORD
+win_vterm_start(HANDLE conout)
+{
+	/* Not failing on errors, they are unlikely to happen and shouldn't break
+	 * further operation too much. */
+
+	/* PDCurses sets output mode to ENABLE_LVB_GRID_WORLDWIDE (0x10) by default
+	 * and sometimes resets it to different values, so can't rely on the state
+	 * being as expected.  ENABLE_PROCESSED_OUTPUT is needed to have ESC
+	 * interpreted as a control character and ENABLE_VIRTUAL_TERMINAL_PROCESSING
+	 * is needed to interpret escape sequences.  The latter has no effect without
+	 * the former. */
+	DWORD orig_mode;
+	if(GetConsoleMode(conout, &orig_mode))
+	{
+		DWORD last_error = GetLastError();
+		LOG_ERROR_MSG("Failed to get console mode of CONOUT (%p).", conout);
+		LOG_WERROR(last_error);
+	}
+	else
+	{
+		orig_mode = 0;
+	}
+
+	DWORD new_mode = orig_mode
+	               | ENABLE_PROCESSED_OUTPUT
+	               | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+	if(SetConsoleMode(conout, new_mode))
+	{
+		DWORD last_error = GetLastError();
+		LOG_ERROR_MSG("Failed to set console mode (0x%08lx) of CONOUT (%p).",
+				new_mode, conout);
+		LOG_WERROR(last_error);
+	}
+
+	return orig_mode;
+}
+
+void
+win_vterm_finish(HANDLE conout, DWORD orig_mode)
+{
+	/* Restore PDCurses' original console mode. */
+	if(!SetConsoleMode(conout, orig_mode))
+	{
+		DWORD last_error = GetLastError();
+		LOG_ERROR_MSG("Failed to restore original console mode (0x%08lx) of "
+				"CONOUT (%p).", orig_mode, conout);
+		LOG_WERROR(last_error);
+	}
 }
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */

--- a/src/utils/utils_win.h
+++ b/src/utils/utils_win.h
@@ -97,6 +97,19 @@ int win_symlink_read(const char link[], char buf[], int buf_len);
  * otherwise. */
 int win_shortcut_read(const char shortcut[], char buf[], int buf_len);
 
+/* Retrieves handle to the console output.  On success, returns the handle,
+ * which must not be closed by the caller.  On error, INVALID_HANDLE_VALUE is
+ * returned. */
+HANDLE win_conout(void);
+
+/* Enables interpretation of control sequences by the terminal.  Returns
+ * console mode that needs to be passed back to win_vterm_finish() or (DWORD)-1
+ * on error. */
+DWORD win_vterm_start(HANDLE conout);
+
+/* Disables interpretation of control sequences by the terminal. */
+void win_vterm_finish(HANDLE conout, DWORD orig_mode);
+
 /* Converts status to exit code.  Input can be -1, meaning that status is
  * unknown.  Returns the exit code or -1 for -1 status. */
 #define status_to_exit_code(status) (status)

--- a/src/vcache.c
+++ b/src/vcache.c
@@ -260,10 +260,12 @@ wait_async_finish(vcache_entry_t *centry)
 		/* Reading is performed in conditional expression. */
 	}
 
+	centry->complete = 1;
 	if(ui_cancellation_requested())
 	{
 		centry->lines.nitems = add_to_string_array(&centry->lines.items,
 				centry->lines.nitems, "[cancelled]");
+		centry->complete = 0;
 	}
 	ui_cancellation_pop();
 

--- a/src/vcache.c
+++ b/src/vcache.c
@@ -208,6 +208,14 @@ vcache_lookup(const char full_path[], const char viewer[], MacroFlags flags,
 		wait_async_finish(centry);
 	}
 
+	if(kind == VK_PASS_THROUGH && !centry->complete)
+	{
+		/* An incomplete pass-through output must never be returned to not confuse
+		 * the terminal. */
+		strlist_t empty_list = {};
+		return empty_list;
+	}
+
 	if(kind != VK_PASS_THROUGH && centry->lines.nitems == 0 &&
 			centry->job != NULL)
 	{


### PR DESCRIPTION
Fixes #1157

## What

Makes `%pd` (`VK_PASS_THROUGH`) fileviewers work correctly on Windows — specifically sixel image viewers such as `chafa -f sixels`.

## Root cause

Three separate issues on Windows prevent pass-through output from rendering:

**1. Wrong screen buffer.**
PDCurses calls `SetConsoleActiveScreenBuffer()` during `initscr()`, so `GetStdHandle(STD_OUTPUT_HANDLE)` returns the original, now-inactive buffer. Writes there are invisible. Fix: open `\\.\CONOUT$`, which always resolves to the currently active screen buffer.

**2. Console mode strips ESC processing.**
PDCurses sets the output mode to `ENABLE_LVB_GRID_WORLDWIDE` (0x10) only, which removes `ENABLE_PROCESSED_OUTPUT` (0x01). Without it, ESC bytes are not treated as control-sequence starts, so `ENABLE_VIRTUAL_TERMINAL_PROCESSING` has no effect and sixel DCS sequences appear as literal text. Fix: set both flags before writing, restore the original mode immediately after so PDCurses' next redraw is unaffected.

**3. Sixel pixels survive character-cell writes.**
Windows Terminal renders sixel graphics in a separate layer that PDCurses' Console API writes do not erase. When the user closes the preview pane, sixel remnants remain visible behind the file listing. Fix: new `ui_pass_through_clear()` covers every cell of a window with an SGR-reset space (`\x1b[0m `) via the same VT path.

## Changes

| File | Change |
|---|---|
| `src/ui/ui.h` | Declare `ui_pass_through_clear()` |
| `src/ui/ui.c` | `ui_pass_through()`: use `CONOUT$` + VT mode for Windows |
| `src/ui/ui.c` | New `ui_pass_through_clear()`: erase sixel pixels via VT path |
| `src/ui/ui.c` | `refresh_view_win()`: skip PDCurses redraw while graphics are shown; call clear on preview toggle-off |
| `src/ui/quickview.c` | `wipe_area()`: call clear before PDCurses fill when kind != VK_TEXTUAL |
| `src/ui/quickview.c` | `qv_draw()`: call clear before `ui_view_erase()` on file cursor move |
| `src/ui/quickview.c` | `get_lines()`: use `VC_SYNC` for `VK_PASS_THROUGH` so data is ready on first render |

All Windows-specific code is inside `#ifdef _WIN32`. No behaviour change on other platforms.

## Testing

Tested on Windows 11 with Windows Terminal (sixel enabled) and the following vifmrc viewer:

```vim
fileviewer {*.jpg,*.jpeg,*.png,...},<image/*>
    \ chafa -f sixels --passthrough=none --font-ratio=0.5 -s %pwx%ph --animate=false --margin-bottom=0 %"c:p %pd
```

- Image renders correctly in the preview pane on cursor move
- Sixel pixels are fully erased when closing the preview pane (`w`)
- Sixel pixels are fully erased when switching to a non-image file while preview is open