### PR TITLE
Add fzf integration plugin and supporting Lua API

### DIFF
--- a/ChangeLog.LuaAPI
+++ b/ChangeLog.LuaAPI
@@ -19,6 +19,8 @@ documented in the regular ChangeLog.
 	with Vifm UI shut down and return its standard output as a string.  Useful
 	for driving interactive terminal programs like fuzzy finders.
 
+	Added vifm.cmds.list() which lists known commands.
+
 	Added "specs" field to vifm.menus.loadcustom() which allows specifying
 	targets for navigation menus independently of whether and how they appear
 	in the menu.

--- a/ChangeLog.LuaAPI
+++ b/ChangeLog.LuaAPI
@@ -21,6 +21,9 @@ documented in the regular ChangeLog.
 
 	Added vifm.cmds.list() which lists known commands.
 
+	Added vifm.keys.list() and vifm.keys.send() for inspecting and executing
+	key bindings.
+
 	Added "specs" field to vifm.menus.loadcustom() which allows specifying
 	targets for navigation menus independently of whether and how they appear
 	in the menu.

--- a/ChangeLog.LuaAPI
+++ b/ChangeLog.LuaAPI
@@ -15,6 +15,10 @@ documented in the regular ChangeLog.
 	Added vifm.redraw() which requests a UI redraw.  Thanks to Steven
 	Xu (stevenxxiu).
 
+	Added "capture" and "mergestreams" fields to vifm.run() to run a command
+	with Vifm UI shut down and return its standard output as a string.  Useful
+	for driving interactive terminal programs like fuzzy finders.
+
 	Added "specs" field to vifm.menus.loadcustom() which allows specifying
 	targets for navigation menus independently of whether and how they appear
 	in the menu.

--- a/ChangeLog.LuaAPI
+++ b/ChangeLog.LuaAPI
@@ -19,6 +19,10 @@ documented in the regular ChangeLog.
 	targets for navigation menus independently of whether and how they appear
 	in the menu.
 
+	Added "stash" and "pos" fields to vifm.menus.loadcustom() which save a
+	custom menu for later reopening (e.g. with :copen) without entering it
+	immediately.
+
 	Fixed a crash on passing a value that's not convertible to a string to
 	VifmView:loadcustom().
 

--- a/data/plugins/fzf/README.md
+++ b/data/plugins/fzf/README.md
@@ -1,0 +1,98 @@
+# fzf
+
+fzf integration for vifm implemented as a Lua plugin.
+
+The plugin registers five commands:
+
+```vim
+:FzfCommand [query]
+:FzfFind [query]
+:FzfFindStashed [query]
+:FzfGrep [pattern]
+:FzfLiveGrep [query]
+```
+
+The plugin currently targets POSIX systems (`/bin/sh`, `/dev/tty`, `find`,
+`grep`/`rg`).  On Windows it is unlikely to work as-is.
+
+## Installation
+
+Put this directory under one of vifm plugin directories, for example:
+
+```sh
+~/.config/vifm/plugins/fzf/init.lua
+```
+
+The plugin directory must contain `init.lua` directly.  If you use
+`--plugins-dir`, point it at the parent directory that contains `fzf`, not at
+the `fzf` directory itself:
+
+```sh
+vifm --plugins-dir ~/.config/vifm/plugins
+```
+
+From the source tree this can be tested with:
+
+```sh
+src/vifm --plugins-dir data/plugins
+```
+
+Restart vifm after copying the plugin if plugins were already loaded.
+
+## Requirements
+
+- `fzf` is required for all commands.
+- `rg` is used by `:FzfFind` when available.
+- `find` is used by `:FzfFind` as a fallback when `rg` is not available.
+- `rg` is used by `:FzfGrep` when available.
+- `grep` is used by `:FzfGrep` as a fallback when `rg` is not available.
+
+## Commands
+
+### `:FzfCommand [query]`
+
+Opens an fzf-backed command palette.  It lists user-defined commands, builtin
+commands and described normal-mode keys.  Selecting a command executes it.  If
+the selected command requires arguments, vifm opens the command line with the
+command name prefilled.
+
+The optional `[query]` is passed to fzf as the initial query.
+
+### `:FzfFind [query]`
+
+Searches files under the current view directory and lets fzf pick a file.
+`rg --files --hidden --no-ignore --one-file-system` is used when available,
+otherwise the command falls back to `find -xdev`.  Mounted directories below the
+search root are skipped; when they can be detected, fzf displays them in its
+header.  After selection, vifm navigates to the picked path.
+
+The optional `[query]` is passed to fzf as the initial query.
+
+### `:FzfFindStashed [query]`
+
+Same as `:FzfFind`, but also stores matching paths in a custom menu so the
+result list can be reopened through vifm's menu history/navigation.
+
+The optional `[query]` is passed to fzf as the initial query.
+
+### `:FzfGrep [pattern]`
+
+Searches file contents under the current view directory and shows matches in
+fzf.  Pressing Enter on a match opens the file at the matching line using
+`'vicmd'`.
+
+The selected match is opened in `'vicmd'` which is expanded by the shell.  When
+`'vicmd'` contains additional arguments the whole string is used verbatim, so
+make sure it works as a `sh` command line.
+
+If `[pattern]` is omitted, `.` is used.
+
+## Example mappings
+
+```vim
+nnoremap ,c :FzfCommand<cr>
+nnoremap ,f :FzfFind<cr>
+nnoremap ,F :FzfFindStashed<cr>
+nnoremap ,g :FzfGrep
+nnoremap ,G :FzfLiveGrep<cr>
+```

--- a/data/plugins/fzf/init.lua
+++ b/data/plugins/fzf/init.lua
@@ -1,0 +1,584 @@
+-- fzf-backed command palette, find and grep integration.
+
+local M = {}
+
+local KIND_COLUMN_WIDTH = 7
+local CMDNAME_COLUMN_MIN_WIDTH = 10
+local KEY_COLUMN_MIN_WIDTH = 10
+local LIVE_GREP_MIN_LEN = 3
+local MOUNT_HEADER_LIMIT = 5
+
+local function fail(msg)
+    vifm.sb.error(msg)
+    return nil
+end
+
+local function executable(name)
+    if not vifm.executable(name) then
+        return fail(name .. " executable not found")
+    end
+    return true
+end
+
+local function quote(value)
+    return vifm.escape(value or "")
+end
+
+local function split_lines(text)
+    local lines = {}
+    if text == nil or text == "" then
+        return lines
+    end
+
+    text = text:gsub("\r\n", "\n")
+    if text:sub(-1) ~= "\n" then
+        text = text .. "\n"
+    end
+
+    for line in text:gmatch("(.-)\n") do
+        lines[#lines + 1] = line
+    end
+    return lines
+end
+
+local function join_lines(lines)
+    if #lines == 0 then
+        return ""
+    end
+    return table.concat(lines, "\n") .. "\n"
+end
+
+local function write_file(path, contents)
+    local file = io.open(path, "wb")
+    if file == nil then
+        return false
+    end
+
+    file:write(contents)
+    file:close()
+    return true
+end
+
+local function run_capture(cmd)
+    local job = vifm.startjob { cmd = cmd }
+    local out = job:stdout():read("*a") or ""
+    job:wait()
+    return out, job:exitcode()
+end
+
+local function run_term_capture(cmd)
+    return vifm.run { cmd = cmd, capture = true }
+end
+
+local function remove_files(paths)
+    for _, path in ipairs(paths) do
+        if path ~= nil then
+            os.remove(path)
+        end
+    end
+end
+
+local function make_temp(contents)
+    local path = os.tmpname()
+    if not write_file(path, contents or "") then
+        return nil
+    end
+    return path
+end
+
+local function run_fzf(input_path, query, prompt, extra)
+    local cmd = table.concat({
+        "fzf",
+        "--query=" .. quote(query or ""),
+        "--prompt=" .. quote(prompt),
+        "--layout=reverse",
+        "--height=100%",
+        extra or "",
+        "< " .. quote(input_path),
+    }, " ")
+    return run_term_capture(cmd)
+end
+
+local function add_header(entries, title)
+    entries[#entries + 1] = {
+        display = "-- " .. title .. " --",
+        kind = "header",
+    }
+end
+
+local function command_width(commands)
+    local width = CMDNAME_COLUMN_MIN_WIDTH
+    for _, cmd in ipairs(commands) do
+        if #cmd.name > width then
+            width = #cmd.name
+        end
+    end
+    return width
+end
+
+local function add_commands(entries, commands, kind, width)
+    local fmt = string.format("%%-%ds :%%-%ds %%s",
+        KIND_COLUMN_WIDTH, width)
+    for _, cmd in ipairs(commands) do
+        if cmd.kind == kind then
+            local label = kind == "builtin" and "builtin" or "usercmd"
+            entries[#entries + 1] = {
+                display = string.format(fmt, label, cmd.name, cmd.description or ""),
+                kind = "command",
+                action = cmd.name,
+                needs_args = (cmd.minargs or 0) > 0,
+            }
+        end
+    end
+end
+
+local function add_keys(entries)
+    local fmt = string.format("%%-%ds %%-%ds %%s",
+        KIND_COLUMN_WIDTH, KEY_COLUMN_MIN_WIDTH)
+    for _, key in ipairs(vifm.keys.list { mode = "normal" }) do
+        if key.shortcut ~= "" and key.action == "" and key.description ~= "" then
+            entries[#entries + 1] = {
+                display = string.format(fmt, "key", key.shortcut, key.description),
+                kind = "key",
+                action = key.shortcut,
+            }
+        end
+    end
+end
+
+local function find_entry(entries, display)
+    for _, entry in ipairs(entries) do
+        if entry.display == display then
+            return entry
+        end
+    end
+    return nil
+end
+
+local function escape_brackets(text)
+    return (text:gsub("<", "<lt>"))
+end
+
+local function execute_palette_entry(entry)
+    if entry == nil or entry.kind == "header" then
+        return
+    end
+
+    if entry.kind == "key" then
+        vifm.keys.send(entry.action)
+        return
+    end
+
+    local action = escape_brackets(entry.action)
+    if entry.needs_args then
+        vifm.keys.send(":" .. action .. " ")
+    else
+        vifm.keys.send(":" .. action .. "<cr>")
+    end
+end
+
+function M.command(info)
+    if not executable("fzf") then
+        return
+    end
+
+    local commands = vifm.cmds.list()
+    local width = command_width(commands)
+    local entries = {}
+
+    add_header(entries, "User-defined commands")
+    add_commands(entries, commands, "user", width)
+    add_header(entries, "Builtin commands")
+    add_commands(entries, commands, "builtin", width)
+    add_header(entries, "Normal mode keys")
+    add_keys(entries)
+
+    local input = {}
+    for _, entry in ipairs(entries) do
+        input[#input + 1] = entry.display
+    end
+
+    local input_path = make_temp(join_lines(input))
+    if input_path == nil then
+        return fail("Failed to prepare fzf input")
+    end
+
+    local selected = run_fzf(input_path, info.args, "Command: ")
+    remove_files { input_path }
+
+    execute_palette_entry(find_entry(entries, selected))
+end
+
+local function make_find_cmd(root)
+    -- stderr is redirected to /dev/null so that error messages don't get
+    -- printed on top of the fzf UI (this would otherwise happen e.g. when rg
+    -- stumbles on pseudo-files in /proc/*/net/* and prints
+    -- "Invalid argument (os error 22)" for each one, making fzf unusable).
+    if vifm.executable("rg") then
+        -- --one-file-system avoids descending into mounted directories,
+        -- --no-ignore and --hidden make rg behave closer to find,
+        -- --no-messages suppresses non-fatal warnings from rg itself.
+        return "rg --files -0 --hidden --no-ignore --no-messages " ..
+            "--one-file-system -- " ..
+            quote(root) .. " 2>/dev/null"
+    end
+
+    -- -xdev is the find equivalent of rg's --one-file-system.
+    return "find " .. quote(root) .. " -xdev -type f -print0 2>/dev/null"
+end
+
+local function normalize_dir(path)
+    while #path > 1 and path:sub(-1) == "/" do
+        path = path:sub(1, -2)
+    end
+    return path
+end
+
+local function list_skipped_mounts(root)
+    if not vifm.executable("awk") or not vifm.exists("/proc/mounts") then
+        return {}
+    end
+
+    root = normalize_dir(root)
+    local cmd = "awk -v root=" .. quote(root) .. " '" ..
+        "{ mp=$2; gsub(/\\\\040/, \" \", mp); " ..
+        "if (mp != root && (root == \"/\" || index(mp, root \"/\") == 1)) " ..
+        "print mp }' /proc/mounts 2>/dev/null"
+    local out = run_capture(cmd)
+    local mounts = {}
+    local seen = {}
+    for _, mount in ipairs(split_lines(out)) do
+        if mount ~= "" and not seen[mount] then
+            seen[mount] = true
+            mounts[#mounts + 1] = mount
+        end
+    end
+    table.sort(mounts)
+    return mounts
+end
+
+local function make_find_header(root)
+    local mounts = list_skipped_mounts(root)
+    if #mounts == 0 then
+        return ""
+    end
+
+    local shown = {}
+    local limit = math.min(#mounts, MOUNT_HEADER_LIMIT)
+    for i = 1, limit do
+        shown[#shown + 1] = mounts[i]
+    end
+
+    local extra = ""
+    if #mounts > limit then
+        extra = string.format(" (+%d more)", #mounts - limit)
+    end
+
+    return "--header=" .. quote("Skipped mount points: " ..
+        table.concat(shown, ", ") .. extra)
+end
+
+local function stash_find_results(view, root, query, selected)
+    vifm.sb.info("FzfFindStashed: saving matches for :copen...")
+
+    local cmd = make_find_cmd(root) .. " | " ..
+        "fzf --read0 --filter=" .. quote(query)
+    local out = run_capture(cmd)
+    local matches = split_lines(out)
+    if #matches == 0 then
+        return
+    end
+
+    local specs = {}
+    local pos = nil
+    for i, path in ipairs(matches) do
+        specs[i] = path
+        if path == selected then
+            pos = i
+        end
+    end
+
+    vifm.menus.loadcustom {
+        title = "FindFZF " .. query .. " @ " .. root,
+        items = matches,
+        specs = specs,
+        withnavigation = true,
+        view = view,
+        stash = true,
+        pos = pos,
+    }
+end
+
+local function find(info, stash)
+    if not executable("fzf") then
+        return
+    end
+
+    local view = vifm.currview()
+    local root = view.cwd
+    local query = info.args or ""
+    local cmd = table.concat({
+        make_find_cmd(root),
+        "|",
+        "fzf",
+        "--read0",
+        "--print-query",
+        "--query=" .. quote(query),
+        "--prompt=" .. quote("File: "),
+        "--layout=reverse",
+        "--height=100%",
+        make_find_header(root),
+    }, " ")
+
+    local lines = split_lines(run_term_capture(cmd))
+    if #lines == 0 then
+        return
+    end
+
+    local next_query = lines[1] or query
+    local picked = lines[2]
+    if stash then
+        stash_find_results(view, root, next_query, picked)
+    end
+
+    if picked ~= nil and not view:gotopath(picked) then
+        fail("Path doesn't exist: " .. picked)
+    end
+end
+
+function M.find(info)
+    find(info, false)
+end
+
+function M.find_stashed(info)
+    find(info, true)
+end
+
+local function make_grep_cmd(root, pattern)
+    if vifm.executable("rg") then
+        return "rg --line-number --column --with-filename " ..
+            "--color=never --smart-case -- " .. quote(pattern) .. " " ..
+            quote(root)
+    end
+
+    if vifm.executable("grep") then
+        return "grep -RInH -I -e " .. quote(pattern) .. " " .. quote(root)
+    end
+
+    return nil
+end
+
+local function extract_grep_match(line)
+    local start = 1
+    while true do
+        local from, to, number = line:find(":(%d+):", start)
+        if from == nil then
+            return nil
+        end
+
+        local path = line:sub(1, from - 1)
+        if vifm.exists(path) then
+            return path, tonumber(number)
+        end
+        start = to + 1
+    end
+end
+
+local function prepare_grep_files(root, pattern)
+    local grep_cmd = make_grep_cmd(root, pattern)
+    if grep_cmd == nil then
+        return fail("Neither rg nor grep executable found")
+    end
+
+    local out = run_capture(grep_cmd)
+    local result_lines = {}
+    local meta_lines = {}
+    local id = 1
+    for _, line in ipairs(split_lines(out)) do
+        local path, line_number = extract_grep_match(line)
+        if path ~= nil then
+            result_lines[#result_lines + 1] = id .. "\t" .. line
+            meta_lines[#meta_lines + 1] = line_number .. "\t" .. path
+            id = id + 1
+        end
+    end
+
+    local results_path = make_temp(join_lines(result_lines))
+    local meta_path = make_temp(join_lines(meta_lines))
+    if results_path == nil or meta_path == nil then
+        remove_files { results_path, meta_path }
+        return fail("Failed to prepare grep results")
+    end
+
+    return results_path, meta_path
+end
+
+local function make_grep_opener(meta_path)
+    local script_path = os.tmpname()
+    -- Note: 'vicmd' is used verbatim in the shell, so any arguments inside it
+    -- (e.g. "vim -g") are interpreted by /bin/sh as usual.
+    local vicmd = tostring(vifm.opts.global.vicmd or "vi")
+    local script = table.concat({
+        "#!/bin/sh",
+        "id=$1",
+        "entry=$(sed -n \"${id}p\" " .. quote(meta_path) .. ")",
+        "line=${entry%%	*}",
+        "path=${entry#*	}",
+        "[ -n \"$path\" ] || exit 0",
+        "exec < /dev/tty > /dev/tty 2>&1",
+        vicmd .. " -f +\"$line\" \"$path\"",
+        "",
+    }, "\n")
+
+    if not write_file(script_path, script) then
+        return nil
+    end
+
+    run_capture("chmod 700 " .. quote(script_path))
+    return script_path
+end
+
+function M.grep(info)
+    if not executable("fzf") then
+        return
+    end
+
+    local pattern = info.args ~= nil and info.args ~= "" and info.args or "."
+    local root = vifm.currview().cwd
+    local results_path, meta_path = prepare_grep_files(root, pattern)
+    if results_path == nil then
+        return
+    end
+
+    local script_path = make_grep_opener(meta_path)
+    if script_path == nil then
+        remove_files { results_path, meta_path }
+        return fail("Failed to create temporary opener for grep results")
+    end
+
+    local bind = "enter:execute(" .. quote(script_path) .. " {1})"
+    local cmd = "fzf --with-nth=2.. --delimiter=" .. quote("\t") ..
+        " --prompt=" .. quote("Grep: ") ..
+        " --layout=reverse --height=100% --bind=" .. quote(bind) ..
+        " < " .. quote(results_path)
+
+    run_term_capture(cmd)
+    remove_files { results_path, meta_path, script_path }
+end
+
+local function make_live_grep_cmd(root)
+    if vifm.executable("rg") then
+        return "rg --line-number --column --with-filename " ..
+            "--color=never --smart-case -- \"$q\" " .. quote(root)
+    end
+
+    if vifm.executable("grep") then
+        return "grep -RInH -I -e \"$q\" " .. quote(root)
+    end
+
+    return nil
+end
+
+local function make_live_grep_script(root, min_len)
+    local grep_cmd = make_live_grep_cmd(root)
+    if grep_cmd == nil then
+        return nil
+    end
+
+    local script_path = os.tmpname()
+    local script = table.concat({
+        "#!/bin/sh",
+        "q=$1",
+        "[ ${#q} -lt " .. min_len .. " ] && exit 0",
+        "exec " .. grep_cmd,
+        "",
+    }, "\n")
+
+    if not write_file(script_path, script) then
+        return nil
+    end
+
+    run_capture("chmod 700 " .. quote(script_path))
+    return script_path
+end
+
+local function make_path_opener()
+    local script_path = os.tmpname()
+    -- Note: 'vicmd' is used verbatim in the shell, so any arguments inside it
+    -- (e.g. "vim -g") are interpreted by /bin/sh as usual.
+    local vicmd = tostring(vifm.opts.global.vicmd or "vi")
+    local script = table.concat({
+        "#!/bin/sh",
+        "path=$1",
+        "line=$2",
+        "[ -n \"$path\" ] || exit 0",
+        "exec < /dev/tty > /dev/tty 2>&1",
+        vicmd .. " -f +\"$line\" \"$path\"",
+        "",
+    }, "\n")
+
+    if not write_file(script_path, script) then
+        return nil
+    end
+
+    run_capture("chmod 700 " .. quote(script_path))
+    return script_path
+end
+
+function M.live_grep(info)
+    if not executable("fzf") then
+        return
+    end
+
+    local root = vifm.currview().cwd
+    local query = info.args or ""
+
+    local search_script = make_live_grep_script(root, LIVE_GREP_MIN_LEN)
+    if search_script == nil then
+        return fail("Neither rg nor grep executable found")
+    end
+
+    local opener = make_path_opener()
+    if opener == nil then
+        remove_files { search_script }
+        return fail("Failed to create temporary opener for grep results")
+    end
+
+    local reload = search_script .. " {q} || true"
+    local cmd = table.concat({
+        "fzf",
+        "--disabled",
+        "--ansi",
+        "--delimiter=" .. quote(":"),
+        "--query=" .. quote(query),
+        "--prompt=" .. quote(string.format("LiveGrep(%d+): ", LIVE_GREP_MIN_LEN)),
+        "--layout=reverse",
+        "--height=100%",
+        "--bind=" .. quote("change:reload:" .. reload),
+        "--bind=" .. quote("start:reload:" .. reload),
+        "--bind=" .. quote("enter:execute(" .. opener .. " {1} {2})"),
+    }, " ")
+
+    run_term_capture(cmd)
+    remove_files { search_script, opener }
+end
+
+local function add_command(name, handler)
+    local added = vifm.cmds.add {
+        name = name,
+        description = "fzf integration",
+        handler = handler,
+        maxargs = -1,
+    }
+    if not added then
+        vifm.sb.error("Failed to register :" .. name)
+    end
+end
+
+add_command("FzfCommand", M.command)
+add_command("FzfFind", M.find)
+add_command("FzfFindStashed", M.find_stashed)
+add_command("FzfGrep", M.grep)
+add_command("FzfLiveGrep", M.live_grep)
+
+return M

--- a/data/vim/doc/app/vifm-lua.txt
+++ b/data/vim/doc/app/vifm-lua.txt
@@ -1130,6 +1130,35 @@ Parameters:~
 Return:~
   `true` on success.
 
+keys.list([{query}])                            *vifm-l_vifm.keys.list()*
+Lists keys of a mode.
+
+Possible fields of {query}:
+ - "mode" (string) (default: "normal")
+   Mode to list: cmdline, nav, normal, visual, menus or view.
+ - "useronly" (boolean) (default: false)
+   Whether to list only user-defined keys.
+
+Return:~
+  Array of tables.  Each table contains:
+   - "shortcut" (string)
+     Left-hand side of the key.
+   - "action" (string)
+     Right-hand side for user-defined mappings or an empty string for builtin
+     and foreign keys.
+   - "description" (string)
+     Description of the key.
+
+keys.send({shortcut})                           *vifm-l_vifm.keys.send()*
+Executes a key sequence written in the same notation as "shortcut" of
+|vifm-l_vifm.keys.add()|.
+
+Parameters:~
+  {shortcut}  Key sequence to execute.
+
+Return:~
+  Integer result code of key execution.
+
 --------------------------------------------------------------------------------
 *vifm-l_vifm.menus*
 
@@ -1742,6 +1771,8 @@ vifm.fs.rmdir({path})                      |vifm-l_vifm.fs.rmdir()|
 
 vifm.keys (table)                          |vifm-l_vifm.keys|
 vifm.keys.add({key})                       |vifm-l_vifm.keys.add()|
+vifm.keys.list([{query}])                  |vifm-l_vifm.keys.list()|
+vifm.keys.send({shortcut})                 |vifm-l_vifm.keys.send()|
 
 vifm.menus (table)                         |vifm-l_vifm.menus|
 vifm.menus.loadcustom({menu})              |vifm-l_vifm.menus.loadcustom()|

--- a/data/vim/doc/app/vifm-lua.txt
+++ b/data/vim/doc/app/vifm-lua.txt
@@ -694,20 +694,33 @@ Possible fields of {info}:
    Command to execute.
  - "pause" (string) (default: "onerror")
    When to pause after command execution: "never", "onerror", "always".
+   Ignored when "capture" is true.
  - "usetermmux" (boolean) (default: true)
    Whether to open terminal multiplexer if support was enabled via
-   |vifm-:screen|.
+   |vifm-:screen|.  Ignored when "capture" is true.
+ - "capture" (boolean) (default: false)
+   When true, runs the command with Vifm UI shut down (giving it full control
+   of the terminal) and captures its standard output.  Useful for interactive
+   programs which need a TTY and produce data on stdout (e.g. fuzzy finders).
+ - "mergestreams" (boolean) (default: false)
+   Only meaningful with "capture".  When true, the command is wrapped so that
+   its standard error is merged into the standard output.
 
 Parameters:~
   {info}  Table with information about what and how to run.
 
 Return:~
-  Exit code of the command, see |vifm-l_VifmJob:exitcode()| for details.
-  Mind that if terminal multiplexer is used, this will be exit code of a
-  command that communicates with the multiplexer.
+  When "capture" is false (default), returns exit code of the command, see
+  |vifm-l_VifmJob:exitcode()| for details.  Mind that if terminal multiplexer
+  is used, this will be exit code of a command that communicates with the
+  multiplexer.
+
+  When "capture" is true, returns captured standard output as a string with
+  trailing newlines stripped.
 
 Raises an error:~
   If {info}.pause has incorrect value.
+  When "capture" is true and the command cannot be started.
 
 vifm.startjob({job})                           *vifm-l_vifm.startjob()*
 Launches an external command as a background job.  Returns without waiting

--- a/data/vim/doc/app/vifm-lua.txt
+++ b/data/vim/doc/app/vifm-lua.txt
@@ -928,6 +928,22 @@ Parameters:~
 Return:~
   `true` on success.
 
+vifm.cmds.list()                               *vifm-l_vifm.cmds.list()*
+Lists known commands.
+
+Return:~
+  Array of tables.  Each table contains:
+   - "kind" (string)
+     Either "builtin" or "user".
+   - "name" (string)
+     Command name.
+   - "description" (string)
+     Command description.
+   - "minargs" (integer)
+     Minimal number of arguments.
+   - "maxargs" (integer)
+     Maximal number of arguments or -1 for no limit.
+
 --------------------------------------------------------------------------------
 *vifm-l_vifm.events*
 
@@ -1710,6 +1726,7 @@ vifm.cmds (table)                          |vifm-l_vifm.cmds|
 vifm.cmds.add({cmd})                       |vifm-l_vifm.cmds.add()|
 vifm.cmds.command({cmd})                   |vifm-l_vifm.cmds.command()|
 vifm.cmds.delcommand({name})               |vifm-l_vifm.cmds.delcommand()|
+vifm.cmds.list()                           |vifm-l_vifm.cmds.list()|
 
 vifm.events (table)                        |vifm-l_vifm.events|
 vifm.events.listen({event})                |vifm-l_vifm.events.listen()|

--- a/data/vim/doc/app/vifm-lua.txt
+++ b/data/vim/doc/app/vifm-lua.txt
@@ -1129,6 +1129,12 @@ Possible fields of {menu}:
    When true, the items are considered to be paths that terminate at `:`
    optionally followed by line and column numbers (like for |vifm-%M|).
    Otherwise, the behaviour is like for |vifm-%m|.
+ - "stash" (boolean) (default: false)
+   When true, the menu is saved for later use (e.g. with |vifm-:copen|) instead
+   of being displayed right away.
+ - "pos" (integer) (optional)
+   1-based cursor position to restore when the menu is reopened.  Useful with
+   "stash".
 
 This function is {unsafe}.
 

--- a/src/lua/vifm.c
+++ b/src/lua/vifm.c
@@ -18,6 +18,9 @@
 
 #include "vifm.h"
 
+#include <stdio.h> /* FILE fclose() */
+#include <stdlib.h> /* free() */
+#include <sys/types.h> /* pid_t */
 #include <unistd.h> /* isatty() */
 
 #include "../cfg/info.h"
@@ -25,11 +28,15 @@
 #include "../menus/users_menu.h"
 #include "../modes/dialogs/msg_dialog.h"
 #include "../modes/cmdline.h"
+#include "../ui/cancellation.h"
 #include "../ui/statusbar.h"
+#include "../ui/ui.h"
 #include "../utils/fs.h"
 #include "../utils/path.h"
 #include "../utils/str.h"
+#include "../utils/string_array.h"
 #include "../utils/utils.h"
+#include "../background.h"
 #include "../event_loop.h"
 #include "../filelist.h"
 #include "../filename_modifiers.h"
@@ -540,7 +547,8 @@ VLUA_API(vifm_redraw)(lua_State *lua)
 	return 0;
 }
 
-/* Runs an external command similar to :!. */
+/* Runs an external command similar to :!.  When "capture" field is set,
+ * captures and returns command's standard output. */
 static int
 VLUA_API(vifm_run)(lua_State *lua)
 {
@@ -548,6 +556,18 @@ VLUA_API(vifm_run)(lua_State *lua)
 
 	vlua_cmn_check_field(lua, 1, "cmd", LUA_TSTRING);
 	const char *cmd = lua_tostring(lua, -1);
+
+	int capture = 0;
+	if(vlua_cmn_check_opt_field(lua, 1, "capture", LUA_TBOOLEAN))
+	{
+		capture = lua_toboolean(lua, -1);
+	}
+
+	int merge_streams = 0;
+	if(vlua_cmn_check_opt_field(lua, 1, "mergestreams", LUA_TBOOLEAN))
+	{
+		merge_streams = lua_toboolean(lua, -1);
+	}
 
 	int use_term_mux = 1;
 	if(vlua_cmn_check_opt_field(lua, 1, "usetermmux", LUA_TBOOLEAN))
@@ -577,7 +597,58 @@ VLUA_API(vifm_run)(lua_State *lua)
 		}
 	}
 
-	lua_pushinteger(lua, rn_shell(cmd, pause, use_term_mux, SHELL_BY_APP));
+	if(!capture)
+	{
+		lua_pushinteger(lua, rn_shell(cmd, pause, use_term_mux, SHELL_BY_APP));
+		return 1;
+	}
+
+	ui_shutdown();
+
+	char *cmd_copy = merge_streams
+	               ? format_str("%s 2>&1", cmd)
+	               : strdup(cmd);
+	if(cmd_copy == NULL)
+	{
+		recover_after_shellout();
+		update_screen(UT_FULL);
+		return luaL_error(lua, "%s", "Out of memory");
+	}
+
+	FILE *output = NULL;
+	pid_t pid = bg_run_and_capture(cmd_copy, /*user_sh=*/1, /*in=*/NULL, &output,
+			/*err=*/NULL);
+	free(cmd_copy);
+	if(pid == (pid_t)-1 || output == NULL)
+	{
+		recover_after_shellout();
+		update_screen(UT_FULL);
+		return luaL_error(lua, "%s", "Failed to start command");
+	}
+
+	ui_cancellation_push_on();
+	size_t len;
+	char *result = read_nonseekable_stream(output, &len, /*cb=*/NULL,
+			/*arg=*/NULL);
+	fclose(output);
+	ui_cancellation_pop();
+
+	recover_after_shellout();
+	update_screen(UT_FULL);
+
+	if(result == NULL)
+	{
+		lua_pushstring(lua, "");
+		return 1;
+	}
+
+	while(len != 0U && result[len - 1] == '\n')
+	{
+		result[--len] = '\0';
+	}
+
+	lua_pushlstring(lua, result, len);
+	free(result);
 	return 1;
 }
 

--- a/src/lua/vifm.c
+++ b/src/lua/vifm.c
@@ -402,8 +402,9 @@ VLUA_API(vifm_makepath)(lua_State *lua)
 	return 1;
 }
 
-/* Member of `vifm.menus` that creates a menu out of list of items.  Returns a
- * boolean, which is true on success. */
+/* Member of `vifm.menus` that creates a menu out of list of items.  When
+ * "stash" field is true, menu is saved for later use without entering it.
+ * Returns a boolean, which is true on success. */
 static int
 VLUA_API(vifm_menus_loadcustom)(lua_State *lua)
 {
@@ -423,6 +424,18 @@ VLUA_API(vifm_menus_loadcustom)(lua_State *lua)
 	if(vlua_cmn_check_opt_field(lua, 1, "withnavigation", LUA_TBOOLEAN))
 	{
 		with_navigation = lua_toboolean(lua, -1);
+	}
+
+	int stash = 0;
+	if(vlua_cmn_check_opt_field(lua, 1, "stash", LUA_TBOOLEAN))
+	{
+		stash = lua_toboolean(lua, -1);
+	}
+
+	int pos = -1;
+	if(vlua_cmn_check_opt_field(lua, 1, "pos", LUA_TNUMBER))
+	{
+		pos = lua_tointeger(lua, -1) - 1;
 	}
 
 	vlua_cmn_check_field(lua, 1, "title", LUA_TSTRING);
@@ -452,8 +465,16 @@ VLUA_API(vifm_menus_loadcustom)(lua_State *lua)
 		}
 	}
 
-	int success =
-		(show_custom_menu(view, title, items, specs, with_navigation) == 0);
+	int success;
+	if(stash)
+	{
+		success =
+			(stash_custom_menu(view, title, items, specs, with_navigation, pos) == 0);
+	}
+	else
+	{
+		success = (show_custom_menu(view, title, items, specs, with_navigation) == 0);
+	}
 	lua_pushboolean(lua, success);
 	return 1;
 

--- a/src/lua/vifm_cmds.c
+++ b/src/lua/vifm_cmds.c
@@ -24,7 +24,9 @@
 #include "../engine/completion.h"
 #include "../ui/statusbar.h"
 #include "../utils/str.h"
+#include "../utils/string_array.h"
 #include "../cmd_completion.h"
+#include "../cmd_handlers.h"
 #include "../status.h"
 #include "lua/lauxlib.h"
 #include "lua/lua.h"
@@ -36,18 +38,23 @@ static int VLUA_API(cmds_add)(lua_State *lua);
 static void parse_cmd_params(vlua_t *vlua, cmd_add_t *cmd);
 static int VLUA_API(cmds_command)(lua_State *lua);
 static int VLUA_API(cmds_delcommand)(lua_State *lua);
+static int VLUA_API(cmds_list_api)(lua_State *lua);
+static void push_cmd_info(lua_State *lua, int index, const char kind[],
+		const char name[], const char descr[], int min_args, int max_args);
 static int lua_cmd_handler(const cmd_info_t *cmd_info);
 static int apply_completion(lua_State *lua, const char str[]);
 
 VLUA_DECLARE_SAFE(cmds_add);
 VLUA_DECLARE_SAFE(cmds_command);
 VLUA_DECLARE_SAFE(cmds_delcommand);
+VLUA_DECLARE_SAFE(cmds_list_api);
 
 /* Functions of `vifm.cmds` table. */
 static const luaL_Reg vifm_cmds_methods[] = {
 	{ "add",        VLUA_REF(cmds_add)        },
 	{ "command",    VLUA_REF(cmds_command)    },
 	{ "delcommand", VLUA_REF(cmds_delcommand) },
+	{ "list",       VLUA_REF(cmds_list_api)   },
 	{ NULL,         NULL                      }
 };
 
@@ -183,6 +190,73 @@ VLUA_API(cmds_delcommand)(lua_State *lua)
 	int success = (vle_cmds_del_user(name) == 0);
 	lua_pushboolean(lua, success);
 	return 1;
+}
+
+/* Member of `vifm.cmds` that lists builtin and custom commands. */
+static int
+VLUA_API(cmds_list_api)(lua_State *lua)
+{
+	lua_createtable(lua, /*narr=*/cmds_list_size, /*nrec=*/0);
+
+	int index = 1;
+	size_t i;
+	for(i = 0U; i < cmds_list_size; ++i)
+	{
+		const cmd_add_t *cmd = &cmds_list[i];
+		if(cmd->name == NULL || cmd->name[0] == '\0')
+		{
+			continue;
+		}
+
+		/* Skip internal placeholder entries like "<USERCMD>". */
+		if(cmd->name[0] == '<')
+		{
+			continue;
+		}
+
+		push_cmd_info(lua, index++, "builtin", cmd->name, cmd->descr,
+				cmd->min_args, cmd->max_args == NOT_DEF ? -1 : cmd->max_args);
+	}
+
+	char **custom_cmds = vle_cmds_list_udcs();
+	if(custom_cmds != NULL)
+	{
+		int j;
+		for(j = 0; custom_cmds[j] != NULL && custom_cmds[j + 1] != NULL; j += 2)
+		{
+			push_cmd_info(lua, index++, "user", custom_cmds[j], custom_cmds[j + 1],
+					0, -1);
+		}
+
+		free_string_array(custom_cmds, count_strings(custom_cmds));
+	}
+
+	return 1;
+}
+
+/* Adds a command description item to a Lua array. */
+static void
+push_cmd_info(lua_State *lua, int index, const char kind[], const char name[],
+		const char descr[], int min_args, int max_args)
+{
+	lua_createtable(lua, /*narr=*/0, /*nrec=*/5);
+
+	lua_pushstring(lua, kind);
+	lua_setfield(lua, -2, "kind");
+
+	lua_pushstring(lua, name);
+	lua_setfield(lua, -2, "name");
+
+	lua_pushstring(lua, descr == NULL ? "" : descr);
+	lua_setfield(lua, -2, "description");
+
+	lua_pushinteger(lua, min_args);
+	lua_setfield(lua, -2, "minargs");
+
+	lua_pushinteger(lua, max_args);
+	lua_setfield(lua, -2, "maxargs");
+
+	lua_seti(lua, -2, index);
 }
 
 /* Handler of all foreign :commands registered from Lua. */

--- a/src/lua/vifm_keys.c
+++ b/src/lua/vifm_keys.c
@@ -21,6 +21,7 @@
 #include <stdlib.h> /* free() */
 #include <wchar.h>
 
+#include "../compat/curses.h"
 #include "../engine/keys.h"
 #include "../modes/modes.h"
 #include "../ui/statusbar.h"
@@ -37,18 +38,39 @@
 #include "vlua_state.h"
 
 static int VLUA_API(keys_add)(lua_State *lua);
+static int VLUA_API(keys_list)(lua_State *lua);
+static int VLUA_API(keys_send)(lua_State *lua);
 
 VLUA_DECLARE_SAFE(keys_add);
+VLUA_DECLARE_SAFE(keys_list);
+VLUA_DECLARE_SAFE(keys_send);
 
 static void parse_modes(vlua_t *vlua, char modes[MODES_COUNT]);
+static int parse_mode_name(const char name[]);
+static void list_key_cb(const wchar_t lhs[], const wchar_t rhs[],
+		const char descr[]);
 static void lua_key_handler(key_info_t key_info, keys_info_t *keys_info);
 static void build_handler_args(lua_State *lua, key_info_t key_info,
 		const keys_info_t *keys_info);
 
+/* Per-call context for list_key_cb.  Stack form supports recursive
+ * invocations. */
+typedef struct keys_list_ctx_t
+{
+	lua_State *lua;
+	int index;
+	struct keys_list_ctx_t *prev;
+}
+keys_list_ctx_t;
+
+static keys_list_ctx_t *keys_list_top;
+
 /* Functions of `vifm.keys` table. */
 static const luaL_Reg vifm_keys_methods[] = {
-	{ "add", VLUA_REF(keys_add) },
-	{ NULL,  NULL               }
+	{ "add",  VLUA_REF(keys_add)  },
+	{ "list", VLUA_REF(keys_list) },
+	{ "send", VLUA_REF(keys_send) },
+	{ NULL,   NULL                }
 };
 
 void
@@ -196,6 +218,140 @@ parse_modes(vlua_t *vlua, char modes[MODES_COUNT])
 
 		lua_pop(vlua->lua, 1);
 	}
+}
+
+/* Member of `vifm.keys` that lists keys of a mode. */
+static int
+VLUA_API(keys_list)(lua_State *lua)
+{
+	int mode = NORMAL_MODE;
+	if(vlua_cmn_check_opt_arg(lua, 1, LUA_TTABLE))
+	{
+		if(vlua_cmn_check_opt_field(lua, 1, "mode", LUA_TSTRING))
+		{
+			mode = parse_mode_name(lua_tostring(lua, -1));
+			if(mode < 0)
+			{
+				return luaL_error(lua, "%s", "Unknown mode");
+			}
+		}
+	}
+
+	int user_only = 0;
+	if(lua_type(lua, 1) == LUA_TTABLE &&
+			vlua_cmn_check_opt_field(lua, 1, "useronly", LUA_TBOOLEAN))
+	{
+		user_only = lua_toboolean(lua, -1);
+	}
+
+	lua_createtable(lua, /*narr=*/0, /*nrec=*/0);
+
+	keys_list_ctx_t ctx = { .lua = lua, .index = 1, .prev = keys_list_top };
+	keys_list_top = &ctx;
+	vle_keys_list(mode, &list_key_cb, user_only);
+	keys_list_top = ctx.prev;
+
+	return 1;
+}
+
+/* Member of `vifm.keys` that executes a key sequence. */
+static int
+VLUA_API(keys_send)(lua_State *lua)
+{
+	const char *shortcut = luaL_checkstring(lua, 1);
+
+	wchar_t *keys = substitute_specs(shortcut);
+	if(keys == NULL)
+	{
+		return luaL_error(lua, "%s", "Failed to parse keys");
+	}
+
+	const int result = vle_keys_exec(keys);
+	free(keys);
+
+	lua_pushinteger(lua, result);
+	return 1;
+}
+
+/* Converts a Lua mode name to the native mode id. */
+static int
+parse_mode_name(const char name[])
+{
+	if(strcmp(name, "cmdline") == 0)
+	{
+		return CMDLINE_MODE;
+	}
+	if(strcmp(name, "nav") == 0)
+	{
+		return NAV_MODE;
+	}
+	if(strcmp(name, "normal") == 0)
+	{
+		return NORMAL_MODE;
+	}
+	if(strcmp(name, "visual") == 0)
+	{
+		return VISUAL_MODE;
+	}
+	if(strcmp(name, "menus") == 0)
+	{
+		return MENU_MODE;
+	}
+	if(strcmp(name, "view") == 0)
+	{
+		return VIEW_MODE;
+	}
+
+	return -1;
+}
+
+/* Callback for collecting key descriptions into a Lua table. */
+static void
+list_key_cb(const wchar_t lhs[], const wchar_t rhs[], const char descr[])
+{
+	keys_list_ctx_t *ctx = keys_list_top;
+	if(ctx == NULL)
+	{
+		return;
+	}
+
+	if(lhs == NULL || rhs == NULL)
+	{
+		return;
+	}
+
+	/* Skip mouse events: their lhs can't be printed in a meaningful form. */
+	if(lhs[0] == K(KEY_MOUSE))
+	{
+		return;
+	}
+
+	lua_State *lua = ctx->lua;
+
+	char *const shortcut = wstr_to_spec(lhs);
+	char *const action = wstr_to_spec(rhs);
+	if(shortcut == NULL || action == NULL)
+	{
+		free(shortcut);
+		free(action);
+		return;
+	}
+
+	lua_createtable(lua, /*narr=*/0, /*nrec=*/3);
+
+	lua_pushstring(lua, shortcut);
+	lua_setfield(lua, -2, "shortcut");
+
+	lua_pushstring(lua, action);
+	lua_setfield(lua, -2, "action");
+
+	lua_pushstring(lua, descr == NULL ? "" : descr);
+	lua_setfield(lua, -2, "description");
+
+	lua_seti(lua, -2, ctx->index++);
+
+	free(shortcut);
+	free(action);
 }
 
 /* Handler of all foreign mappings registered from Lua. */

--- a/src/menus/menus.c
+++ b/src/menus/menus.c
@@ -882,6 +882,19 @@ menus_put_on_stash(menu_state_t *ms)
 	}
 }
 
+void
+menus_stash(menu_data_t *m)
+{
+	if(can_stash_menu(m))
+	{
+		stash_menu(m);
+	}
+	else if(m->initialized)
+	{
+		deinit_menu_data(m);
+	}
+}
+
 int
 menus_unstash(view_t *view)
 {

--- a/src/menus/menus.h
+++ b/src/menus/menus.h
@@ -127,6 +127,10 @@ void menus_switch_to(menu_data_t *m);
  * disrupting the menu in any way. */
 void menus_put_on_stash(menu_state_t *ms);
 
+/* Saves menu for future use by :copen without displaying it.  Takes ownership
+ * of menu data. */
+void menus_stash(menu_data_t *m);
+
 /* Restore previously saved menu.  Returns non-zero if status bar message should
  * be saved. */
 int menus_unstash(struct view_t *view);

--- a/src/menus/users_menu.c
+++ b/src/menus/users_menu.c
@@ -92,6 +92,48 @@ fail:
 	return 1;
 }
 
+int
+stash_custom_menu(view_t *view, const char title[], strlist_t items,
+		strlist_t specs, int with_navigation, int pos)
+{
+	static menu_data_t m;
+
+	/* Avoid saving menus that couldn't be reopened later. */
+	if(items.nitems == 0)
+	{
+		goto fail;
+	}
+
+	if(specs.nitems != 0 && specs.nitems != items.nitems)
+	{
+		goto fail;
+	}
+
+	menus_init_data(&m, view, strdup(title), strdup("No items"));
+
+	m.extra_data = with_navigation;
+	m.stashable = 1;
+	m.execute_handler = &execute_users_cb;
+	m.get_spec = &users_get_spec;
+	m.key_handler = &users_khandler;
+
+	m.len = items.nitems;
+	m.items = items.items;
+	m.data = specs.items;
+	if(pos >= 0 && pos < m.len)
+	{
+		m.pos = pos;
+	}
+
+	menus_stash(&m);
+	return 0;
+
+fail:
+	free_string_array(items.items, items.nitems);
+	free_string_array(specs.items, specs.nitems);
+	return 1;
+}
+
 /* Callback that is called when menu item is selected.  Should return non-zero
  * to stay in menu mode. */
 static int

--- a/src/menus/users_menu.h
+++ b/src/menus/users_menu.h
@@ -35,6 +35,12 @@ int show_user_menu(struct view_t *view, const char command[],
 int show_custom_menu(struct view_t *view, const char title[],
 		struct strlist_t items, struct strlist_t specs, int with_navigation);
 
+/* Stashes a menu with custom contents.  Takes ownership of items and specs.
+ * Returns zero on success. */
+int stash_custom_menu(struct view_t *view, const char title[],
+		struct strlist_t items, struct strlist_t specs, int with_navigation,
+		int pos);
+
 #endif /* VIFM__MENUS__USERS_MENU_H__ */
 
 /* vim: set tabstop=2 softtabstop=2 shiftwidth=2 noexpandtab cinoptions-=(0 : */

--- a/src/tags.c
+++ b/src/tags.c
@@ -785,6 +785,8 @@ const char *tags[] = {
 	"vifm-l_vifm.input()",
 	"vifm-l_vifm.keys",
 	"vifm-l_vifm.keys.add()",
+	"vifm-l_vifm.keys.list()",
+	"vifm-l_vifm.keys.send()",
 	"vifm-l_vifm.makepath()",
 	"vifm-l_vifm.menus",
 	"vifm-l_vifm.menus.loadcustom()",

--- a/src/tags.c
+++ b/src/tags.c
@@ -764,6 +764,7 @@ const char *tags[] = {
 	"vifm-l_vifm.cmds.add()",
 	"vifm-l_vifm.cmds.command()",
 	"vifm-l_vifm.cmds.delcommand()",
+	"vifm-l_vifm.cmds.list()",
 	"vifm-l_vifm.currview()",
 	"vifm-l_vifm.errordialog()",
 	"vifm-l_vifm.escape()",

--- a/tests/lua/api.c
+++ b/tests/lua/api.c
@@ -268,6 +268,23 @@ TEST(vifm_run)
 	conf_teardown();
 }
 
+TEST(vifm_run_capture, IF(not_windows))
+{
+	conf_setup();
+
+	GLUA_EQ(vlua, "hi",
+			"print(vifm.run { cmd = 'printf hi', capture = true })");
+
+	GLUA_EQ(vlua, "outerr",
+			"print(vifm.run {"
+			"  cmd = '(printf out; printf err 1>&2)',"
+			"  capture = true,"
+			"  mergestreams = true,"
+			"})");
+
+	conf_teardown();
+}
+
 TEST(vifm_input)
 {
 	view_setup(&lwin);

--- a/tests/lua/api_cmds.c
+++ b/tests/lua/api_cmds.c
@@ -214,6 +214,33 @@ TEST(cmds_names_with_numbers)
 			"if not r then print 'fail' end");
 }
 
+TEST(cmds_list)
+{
+	cmds_init();
+
+	GLUA_EQ(vlua, "",
+			"vifm.cmds.add {"
+			"  name = 'fzfsample',"
+			"  handler = function() end"
+			"}");
+
+	GLUA_EQ(vlua, "command\tbuiltin\t0\t-1",
+			"for _, cmd in ipairs(vifm.cmds.list()) do "
+			"  if cmd.name == 'command' then "
+			"    print(cmd.name, cmd.kind, cmd.minargs, cmd.maxargs) "
+			"    break "
+			"  end "
+			"end");
+
+	GLUA_EQ(vlua, "fzfsample\tuser\t0\t-1",
+			"for _, cmd in ipairs(vifm.cmds.list()) do "
+			"  if cmd.name == 'fzfsample' then "
+			"    print(cmd.name, cmd.kind, cmd.minargs, cmd.maxargs) "
+			"    break "
+			"  end "
+			"end");
+}
+
 TEST(cmds_delcommand)
 {
 	GLUA_EQ(vlua, "",

--- a/tests/lua/api_keys.c
+++ b/tests/lua/api_keys.c
@@ -251,6 +251,43 @@ TEST(keys_add)
 	assert_string_equal("22\"", ui_sb_last());
 }
 
+TEST(keys_list)
+{
+	GLUA_EQ(vlua, "true",
+			"print(vifm.keys.add {"
+			"  shortcut = 'X',"
+			"  description = 'custom key',"
+			"  modes = { 'normal' },"
+			"  handler = function() end,"
+			"})");
+
+	GLUA_EQ(vlua, "X\tcustom key",
+			"for _, key in ipairs(vifm.keys.list {"
+			"  mode = 'normal',"
+			"  useronly = true,"
+			"}) do "
+			"  if key.shortcut == 'X' then "
+			"    print(key.shortcut, key.description) "
+			"    break "
+			"  end "
+			"end");
+}
+
+TEST(keys_send)
+{
+	GLUA_EQ(vlua, "true",
+			"handled = false "
+			"print(vifm.keys.add {"
+			"  shortcut = 'X',"
+			"  modes = { 'normal' },"
+			"  handler = function() handled = true end,"
+			"})");
+
+	GLUA_EQ(vlua, "true",
+			"vifm.keys.send('X')"
+			"print(handled)");
+}
+
 TEST(keys_add_selector)
 {
 	GLUA_EQ(vlua, "",

--- a/tests/lua/api_menus.c
+++ b/tests/lua/api_menus.c
@@ -112,6 +112,32 @@ TEST(menus_loadcustom_no_navigation)
 	assert_false(menu_get_current()->extra_data);
 }
 
+TEST(menus_loadcustom_stash)
+{
+	menus_drop_stash();
+
+	GLUA_EQ(vlua, "true",
+			"print(vifm.menus.loadcustom {"
+			"  title = 'saved',"
+			"  items = { 'a', 'b' },"
+			"  stash = true,"
+			"  pos = 2,"
+			"})");
+	assert_false(vle_mode_is(MENU_MODE));
+
+	assert_success(menus_unstash(&lwin));
+	assert_true(vle_mode_is(MENU_MODE));
+	assert_true(menus_get_view(menu_get_current()) == &lwin);
+	assert_string_equal("saved", menu_get_current()->title);
+	assert_int_equal(2, menu_get_current()->len);
+	assert_string_equal("a", menu_get_current()->items[0]);
+	assert_string_equal("b", menu_get_current()->items[1]);
+	assert_int_equal(1, menu_get_current()->pos);
+	assert_false(menu_get_current()->extra_data);
+
+	menus_drop_stash();
+}
+
 TEST(menus_loadcustom_navigation)
 {
 	make_abs_path(lwin.curr_dir, sizeof(lwin.curr_dir), ".", "", NULL);


### PR DESCRIPTION
## Summary

This adds a bundled Lua-based fzf plugin and the Lua API pieces it needs.

API changes:
- add `vifm.run { capture = true, mergestreams = true }`
- add `vifm.cmds.list()`
- add `vifm.keys.list()` and `vifm.keys.send()`
- add `stash` and `pos` fields to `vifm.menus.loadcustom()`
- expose `os.remove()` in the restricted Lua environment
- update Lua API docs, tags, changelog and tests

Plugin changes:
- add `data/plugins/fzf`
- provide `:FzfCommand`, `:FzfFind`, `:FzfFindStashed`, `:FzfGrep`, and `:FzfLiveGrep`
- document requirements and usage in the plugin README

The plugin currently targets POSIX-like systems and uses `/bin/sh`, `/dev/tty`, `fzf`, plus `rg` or `grep`/`find` fallbacks.
