### PR TITLE
Refer to 'millerview' instead of 'miller' in sample vifmrc

### DIFF
--- a/data/vifmrc
+++ b/data/vifmrc
@@ -143,8 +143,8 @@ endif
 " Add -s to the default value to suppress "Permission denied" errors
 set grepprg="grep -n -H -I -r -s %i %a %s"
 
-" Enable preview of files in the right miller column (add `set miller` to turn
-" it on)
+" Enable preview of files in the right miller column (add `set millerview` to
+" turn it on)
 set milleroptions+=rpreview:all
 
 " List of color schemes to try (picks the first one supported by the terminal)

--- a/data/vifmrc-osx
+++ b/data/vifmrc-osx
@@ -141,8 +141,8 @@ endif
 " Add -s to the default value to suppress "Permission denied" errors
 set grepprg="grep -n -H -I -r -s %i %a %s"
 
-" Enable preview of files in the right miller column (add `set miller` to turn
-" it on)
+" Enable preview of files in the right miller column (add `set millerview` to
+" turn it on)
 set milleroptions+=rpreview:all
 
 " List of color schemes to try (picks the first one supported by the terminal)


### PR DESCRIPTION
Hi, I just started using vifm and am having a blast so far. Thank you very much!

There's a small error in the comment to the newly added `milleroptions` in the sample vifmrc: `set miller` won't help the user, `set millerview` will.
This modest patch rectifies that.

I see that you keep your commit messages generally under 50, and this one is just 51 characters long: I can probably modify the subject somewhat if it's preferable :-)